### PR TITLE
Remove incorrect validation on primary mappings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2025-11-25
+
+### Fixed
+- Remove client-side validation for primary identifiers in sync resources. The Census API now handles this validation, fixing issues with certain destination types like Google Sheets that don't require explicit primary identifier mappings. ([#1](https://github.com/sutrolabs/terraform-provider-census/issues/1))
+
 ## [0.2.0] - 2025-10-23 - Initial Public Release
 
 This is the first official release of the Census Terraform Provider on the [Terraform Registry](https://registry.terraform.io/providers/sutrolabs/census/latest).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Remove client-side validation for primary identifiers in sync resources. The Census API now handles this validation, fixing issues with certain destination types like Google Sheets that don't require explicit primary identifier mappings. ([#1](https://github.com/sutrolabs/terraform-provider-census/issues/1))
+- Fix sync `paused` attribute not updating correctly when changing from `true` to `false`. Removed `omitempty` JSON tag from boolean field to ensure the value is always sent to the API.
 
 ## [0.2.0] - 2025-10-23 - Initial Public Release
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 BINARY_NAME=terraform-provider-census
-VERSION=0.2.0
+VERSION=0.2.1
 BUILD_DIR=bin
 LDFLAGS=-ldflags "-X main.version=${VERSION}"
 

--- a/census/client/sync.go
+++ b/census/client/sync.go
@@ -193,7 +193,7 @@ type CreateSyncRequest struct {
 	// Mode - live vs triggered with trigger configurations (replaces schedule fields)
 	Mode *SyncMode `json:"mode,omitempty"`
 
-	Paused bool `json:"paused,omitempty"`
+	Paused bool `json:"paused"`
 
 	// Field configuration
 	FieldBehavior      string `json:"field_behavior,omitempty"`      // sync_all_properties or specific_properties
@@ -235,7 +235,7 @@ type UpdateSyncRequest struct {
 	// Mode - live vs triggered with trigger configurations (replaces schedule fields)
 	Mode *SyncMode `json:"mode,omitempty"`
 
-	Paused bool `json:"paused,omitempty"`
+	Paused bool `json:"paused"`
 
 	// Field configuration
 	FieldBehavior      string `json:"field_behavior,omitempty"`      // sync_all_properties or specific_properties

--- a/census/provider/resource_sync.go
+++ b/census/provider/resource_sync.go
@@ -616,11 +616,6 @@ func resourceSyncCreate(ctx context.Context, d *schema.ResourceData, meta interf
 	destinationAttributes := ExpandDestinationAttributes(d.Get("destination_attributes").([]interface{}))
 	fieldMappings := ExpandFieldMappings(d.Get("field_mapping").([]interface{}))
 
-	// Validate exactly one primary identifier
-	if err := validatePrimaryIdentifier(fieldMappings); err != nil {
-		return diag.FromErr(err)
-	}
-
 	// Get operation from top-level field (per OpenAPI spec)
 	operation := d.Get("operation").(string)
 
@@ -1832,25 +1827,6 @@ func convertToString(value interface{}) string {
 	default:
 		return fmt.Sprintf("%v", v)
 	}
-}
-
-// validatePrimaryIdentifier ensures exactly one field mapping has is_primary_identifier = true
-func validatePrimaryIdentifier(fieldMappings []client.FieldMapping) error {
-	primaryCount := 0
-	for _, fm := range fieldMappings {
-		if fm.IsPrimaryIdentifier {
-			primaryCount++
-		}
-	}
-
-	if primaryCount == 0 {
-		return fmt.Errorf("exactly one field_mapping must have is_primary_identifier = true, but found 0")
-	}
-	if primaryCount > 1 {
-		return fmt.Errorf("exactly one field_mapping must have is_primary_identifier = true, but found %d", primaryCount)
-	}
-
-	return nil
 }
 
 // convertFieldMappingsToMappingAttributes converts Terraform FieldMapping to Census API MappingAttributes

--- a/census/tests/provider/unit/resource_sync_test.go
+++ b/census/tests/provider/unit/resource_sync_test.go
@@ -576,3 +576,141 @@ func TestCleanEmptyStrings(t *testing.T) {
 		})
 	}
 }
+
+// ============================================================================
+// Primary Identifier Validation Tests
+// ============================================================================
+// These tests verify that client-side validation of primary identifiers has been removed.
+// The Census API now handles primary identifier validation, allowing destinations like
+// Google Sheets that don't require explicit primary identifiers.
+
+func TestExpandFieldMappings_NoPrimaryIdentifier(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []interface{}
+		expected []client.FieldMapping
+	}{
+		{
+			name: "mappings without primary identifier - allowed for destinations like Google Sheets",
+			input: []interface{}{
+				map[string]interface{}{
+					"from": "city",
+					"to":   "City",
+					"type": "direct",
+				},
+				map[string]interface{}{
+					"from": "state",
+					"to":   "State",
+					"type": "direct",
+				},
+			},
+			expected: []client.FieldMapping{
+				{
+					From:                "city",
+					To:                  "City",
+					Type:                "direct",
+					IsPrimaryIdentifier: false,
+				},
+				{
+					From:                "state",
+					To:                  "State",
+					Type:                "direct",
+					IsPrimaryIdentifier: false,
+				},
+			},
+		},
+		{
+			name: "single mapping without primary identifier",
+			input: []interface{}{
+				map[string]interface{}{
+					"from": "email",
+					"to":   "Email",
+				},
+			},
+			expected: []client.FieldMapping{
+				{
+					From:                "email",
+					To:                  "Email",
+					Type:                "direct",
+					IsPrimaryIdentifier: false,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := provider.ExpandFieldMappings(tt.input)
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("ExpandFieldMappings() got = %+v, want %+v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestExpandFieldMappings_GoogleSheetsScenario(t *testing.T) {
+	// Google Sheets syncs don't require primary identifiers
+	// This test verifies that field mappings work correctly for such destinations
+	tests := []struct {
+		name     string
+		input    []interface{}
+		expected int // Expected number of mappings
+	}{
+		{
+			name: "Google Sheets sync with replace operation - no primary identifier needed",
+			input: []interface{}{
+				map[string]interface{}{
+					"from": "city",
+					"to":   "City",
+				},
+				map[string]interface{}{
+					"from": "state",
+					"to":   "State",
+				},
+				map[string]interface{}{
+					"from": "population",
+					"to":   "Population",
+				},
+			},
+			expected: 3,
+		},
+		{
+			name: "Google Sheets sync with constant values - no primary identifier",
+			input: []interface{}{
+				map[string]interface{}{
+					"from": "name",
+					"to":   "Name",
+				},
+				map[string]interface{}{
+					"type":     "constant",
+					"constant": "2024",
+					"to":       "Year",
+				},
+			},
+			expected: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := provider.ExpandFieldMappings(tt.input)
+			if len(result) != tt.expected {
+				t.Errorf("ExpandFieldMappings() returned %d mappings, want %d", len(result), tt.expected)
+			}
+
+			// Verify all mappings are properly expanded
+			for i, mapping := range result {
+				if mapping.To == "" {
+					t.Errorf("ExpandFieldMappings() mapping %d has empty 'to' field", i)
+				}
+			}
+
+			// Verify no primary identifiers are set
+			for i, mapping := range result {
+				if mapping.IsPrimaryIdentifier {
+					t.Errorf("ExpandFieldMappings() mapping %d unexpectedly has IsPrimaryIdentifier=true", i)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description of the change

Removes validation on primary key mappings at the terraform level - we should let the Census API do this validation. Google Sheets destinations don't require a primary key.

Should resolve Issue #1 
