### PR TITLE
Add support for show.unless conditions in credential validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Fix Snowflake source validation to support keypair authentication. The provider now correctly handles `show.unless` conditions in field metadata, allowing sources to be created with `use_keypair=true` without requiring a password field.
+
 ## [0.2.1] - 2025-11-25
 
 ### Fixed

--- a/census/client/source.go
+++ b/census/client/source.go
@@ -415,6 +415,62 @@ func (c *Client) ValidateSourceCredentials(ctx context.Context, sourceType strin
 							isRequired = false
 						}
 					}
+				} else if unlessField, exists := showMap["unless"]; exists {
+					// Handle "unless" conditions: field is required UNLESS condition is true
+					// Example: "show": {"unless": {"use_keypair": {"eq": true}}}
+					conditionMet := false
+
+					if unlessFieldMap, ok := unlessField.(map[string]interface{}); ok {
+						for conditionField, expectedValue := range unlessFieldMap {
+							if conditionValue, conditionExists := credentials[conditionField]; conditionExists {
+								// Check if condition matches expected value
+								if expectedMap, ok := expectedValue.(map[string]interface{}); ok {
+									if eqValue, hasEq := expectedMap["eq"]; hasEq {
+										// Handle {"eq": value} comparisons
+										if expectedBool, ok := eqValue.(bool); ok {
+											// Expected value is boolean
+											if condBool, ok := conditionValue.(bool); ok {
+												if condBool == expectedBool {
+													conditionMet = true
+												}
+											} else if condStr, ok := conditionValue.(string); ok {
+												// Convert string to boolean for comparison
+												condBool := condStr == "true" || condStr == "1"
+												if condBool == expectedBool {
+													conditionMet = true
+												}
+											}
+										} else if expectedStr, ok := eqValue.(string); ok {
+											// Expected value is string
+											if condStr, ok := conditionValue.(string); ok {
+												if condStr == expectedStr {
+													conditionMet = true
+												}
+											}
+										}
+									}
+								} else if expectedBool, ok := expectedValue.(bool); ok {
+									// Simple boolean comparison without "eq" wrapper
+									if condBool, ok := conditionValue.(bool); ok {
+										if condBool == expectedBool {
+											conditionMet = true
+										}
+									} else if condStr, ok := conditionValue.(string); ok {
+										condBool := condStr == "true" || condStr == "1"
+										if condBool == expectedBool {
+											conditionMet = true
+										}
+									}
+								}
+							}
+							break // Handle first condition for now
+						}
+					}
+
+					// If "unless" condition is met, field is NOT required
+					if conditionMet {
+						isRequired = false
+					}
 				}
 			}
 		}

--- a/census/tests/client/source_validation_test.go
+++ b/census/tests/client/source_validation_test.go
@@ -1,0 +1,376 @@
+package client_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sutrolabs/terraform-provider-census/census/client"
+)
+
+// TestValidateSourceCredentials_SnowflakePassword tests Snowflake password authentication validation
+func TestValidateSourceCredentials_SnowflakePassword(t *testing.T) {
+	// Mock source types response
+	sourceTypes := map[string]interface{}{
+		"status": "success",
+		"data": []interface{}{
+			map[string]interface{}{
+				"service_name": "snowflake",
+				"configuration_fields": map[string]interface{}{
+					"fields": []interface{}{
+						map[string]interface{}{
+							"id":    "account",
+							"label": "Account",
+							"type":  "string",
+							"rules": []interface{}{"required"},
+						},
+						map[string]interface{}{
+							"id":    "username",
+							"label": "Username",
+							"type":  "string",
+							"rules": []interface{}{"required"},
+						},
+						map[string]interface{}{
+							"id":                     "password",
+							"label":                  "Password",
+							"type":                   "string",
+							"rules":                  []interface{}{"required"},
+							"is_password_type_field": true,
+							"show": map[string]interface{}{
+								"unless": map[string]interface{}{
+									"use_keypair": map[string]interface{}{
+										"eq": true,
+									},
+								},
+							},
+						},
+						map[string]interface{}{
+							"id":    "database",
+							"label": "Database",
+							"type":  "string",
+							"rules": []interface{}{"required"},
+						},
+						map[string]interface{}{
+							"id":    "warehouse",
+							"label": "Warehouse",
+							"type":  "string",
+							"rules": []interface{}{"required"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/source_types" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(sourceTypes)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	c, err := client.NewClient(&client.Config{
+		PersonalAccessToken: "test-token",
+		BaseURL:             server.URL,
+		Region:              "us",
+	})
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	// Test valid password-based credentials
+	credentials := map[string]interface{}{
+		"account":   "test.us-east-1",
+		"username":  "census",
+		"password":  "secret123",
+		"database":  "PRODUCTION",
+		"warehouse": "COMPUTE_WH",
+	}
+
+	err = c.ValidateSourceCredentials(context.Background(), "snowflake", credentials, "test-workspace-token")
+	if err != nil {
+		t.Errorf("Expected no error for valid password credentials, got: %v", err)
+	}
+
+	// Test missing password (should fail)
+	invalidCredentials := map[string]interface{}{
+		"account":   "test.us-east-1",
+		"username":  "census",
+		"database":  "PRODUCTION",
+		"warehouse": "COMPUTE_WH",
+	}
+
+	err = c.ValidateSourceCredentials(context.Background(), "snowflake", invalidCredentials, "test-workspace-token")
+	if err == nil {
+		t.Error("Expected error for missing password, got nil")
+	}
+}
+
+// TestValidateSourceCredentials_SnowflakeKeypair tests Snowflake keypair authentication validation
+func TestValidateSourceCredentials_SnowflakeKeypair(t *testing.T) {
+	// Mock source types response with unless condition
+	sourceTypes := map[string]interface{}{
+		"status": "success",
+		"data": []interface{}{
+			map[string]interface{}{
+				"service_name": "snowflake",
+				"configuration_fields": map[string]interface{}{
+					"fields": []interface{}{
+						map[string]interface{}{
+							"id":    "account",
+							"label": "Account",
+							"type":  "string",
+							"rules": []interface{}{"required"},
+						},
+						map[string]interface{}{
+							"id":    "username",
+							"label": "Username",
+							"type":  "string",
+							"rules": []interface{}{"required"},
+						},
+						map[string]interface{}{
+							"id":                     "password",
+							"label":                  "Password",
+							"type":                   "string",
+							"rules":                  []interface{}{"required"},
+							"is_password_type_field": true,
+							"show": map[string]interface{}{
+								"unless": map[string]interface{}{
+									"use_keypair": map[string]interface{}{
+										"eq": true,
+									},
+								},
+							},
+						},
+						map[string]interface{}{
+							"id":    "use_keypair",
+							"label": "Use Keypair",
+							"type":  "boolean",
+						},
+						map[string]interface{}{
+							"id":    "private_key_pkcs8",
+							"label": "Private Key (PKCS8)",
+							"type":  "string",
+						},
+						map[string]interface{}{
+							"id":    "database",
+							"label": "Database",
+							"type":  "string",
+							"rules": []interface{}{"required"},
+						},
+						map[string]interface{}{
+							"id":    "warehouse",
+							"label": "Warehouse",
+							"type":  "string",
+							"rules": []interface{}{"required"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/source_types" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(sourceTypes)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	c, err := client.NewClient(&client.Config{
+		PersonalAccessToken: "test-token",
+		BaseURL:             server.URL,
+		Region:              "us",
+	})
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	// Test valid keypair credentials (use_keypair=true, no password required)
+	credentials := map[string]interface{}{
+		"account":           "test.us-east-1",
+		"username":          "census",
+		"use_keypair":       true,
+		"private_key_pkcs8": "-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----",
+		"database":          "PRODUCTION",
+		"warehouse":         "COMPUTE_WH",
+	}
+
+	err = c.ValidateSourceCredentials(context.Background(), "snowflake", credentials, "test-workspace-token")
+	if err != nil {
+		t.Errorf("Expected no error for valid keypair credentials, got: %v", err)
+	}
+
+	// Test keypair with boolean as string
+	credentialsStringBool := map[string]interface{}{
+		"account":           "test.us-east-1",
+		"username":          "census",
+		"use_keypair":       "true",
+		"private_key_pkcs8": "-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----",
+		"database":          "PRODUCTION",
+		"warehouse":         "COMPUTE_WH",
+	}
+
+	err = c.ValidateSourceCredentials(context.Background(), "snowflake", credentialsStringBool, "test-workspace-token")
+	if err != nil {
+		t.Errorf("Expected no error for valid keypair credentials with string boolean, got: %v", err)
+	}
+
+	// Test keypair=false should still require password
+	credentialsKeypairFalse := map[string]interface{}{
+		"account":     "test.us-east-1",
+		"username":    "census",
+		"use_keypair": false,
+		"database":    "PRODUCTION",
+		"warehouse":   "COMPUTE_WH",
+	}
+
+	err = c.ValidateSourceCredentials(context.Background(), "snowflake", credentialsKeypairFalse, "test-workspace-token")
+	if err == nil {
+		t.Error("Expected error when use_keypair=false and password missing, got nil")
+	}
+}
+
+// TestValidateSourceCredentials_ShowIfCondition tests show.if conditional logic
+func TestValidateSourceCredentials_ShowIfCondition(t *testing.T) {
+	// Mock source types with "show.if" condition
+	sourceTypes := map[string]interface{}{
+		"status": "success",
+		"data": []interface{}{
+			map[string]interface{}{
+				"service_name": "postgres",
+				"configuration_fields": map[string]interface{}{
+					"fields": []interface{}{
+						map[string]interface{}{
+							"id":    "host",
+							"label": "Host",
+							"type":  "string",
+							"rules": []interface{}{"required"},
+						},
+						map[string]interface{}{
+							"id":    "ssh_tunnel_enabled",
+							"label": "SSH Tunnel Enabled",
+							"type":  "boolean",
+						},
+						map[string]interface{}{
+							"id":    "ssh_host",
+							"label": "SSH Host",
+							"type":  "string",
+							"rules": []interface{}{"required"},
+							"show": map[string]interface{}{
+								"if": map[string]interface{}{
+									"ssh_tunnel_enabled": true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/source_types" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(sourceTypes)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	c, err := client.NewClient(&client.Config{
+		PersonalAccessToken: "test-token",
+		BaseURL:             server.URL,
+		Region:              "us",
+	})
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	// Test with SSH tunnel disabled - ssh_host not required
+	credentialsNoSSH := map[string]interface{}{
+		"host":               "db.example.com",
+		"ssh_tunnel_enabled": false,
+	}
+
+	err = c.ValidateSourceCredentials(context.Background(), "postgres", credentialsNoSSH, "test-workspace-token")
+	if err != nil {
+		t.Errorf("Expected no error when SSH tunnel disabled, got: %v", err)
+	}
+
+	// Test with SSH tunnel enabled - ssh_host required
+	credentialsWithSSH := map[string]interface{}{
+		"host":               "db.example.com",
+		"ssh_tunnel_enabled": true,
+		"ssh_host":           "tunnel.example.com",
+	}
+
+	err = c.ValidateSourceCredentials(context.Background(), "postgres", credentialsWithSSH, "test-workspace-token")
+	if err != nil {
+		t.Errorf("Expected no error when SSH tunnel enabled with ssh_host, got: %v", err)
+	}
+
+	// Test with SSH tunnel enabled but missing ssh_host - should fail
+	credentialsSSHNoHost := map[string]interface{}{
+		"host":               "db.example.com",
+		"ssh_tunnel_enabled": true,
+	}
+
+	err = c.ValidateSourceCredentials(context.Background(), "postgres", credentialsSSHNoHost, "test-workspace-token")
+	if err == nil {
+		t.Error("Expected error when SSH tunnel enabled but ssh_host missing, got nil")
+	}
+}
+
+// TestValidateSourceCredentials_UnknownSourceType tests validation with unknown source type
+func TestValidateSourceCredentials_UnknownSourceType(t *testing.T) {
+	sourceTypes := map[string]interface{}{
+		"status": "success",
+		"data": []interface{}{
+			map[string]interface{}{
+				"service_name": "snowflake",
+				"configuration_fields": map[string]interface{}{
+					"fields": []interface{}{},
+				},
+			},
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/source_types" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(sourceTypes)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	c, err := client.NewClient(&client.Config{
+		PersonalAccessToken: "test-token",
+		BaseURL:             server.URL,
+		Region:              "us",
+	})
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	credentials := map[string]interface{}{}
+
+	err = c.ValidateSourceCredentials(context.Background(), "unknown_type", credentials, "test-workspace-token")
+	if err == nil {
+		t.Error("Expected error for unknown source type, got nil")
+	}
+	if err != nil && err.Error() != "unknown source type: unknown_type" {
+		t.Errorf("Expected 'unknown source type' error, got: %v", err)
+	}
+}

--- a/docs/resources/source.md
+++ b/docs/resources/source.md
@@ -4,7 +4,7 @@ Manages a Census data source connection. Sources connect to data warehouses like
 
 ## Example Usage
 
-### Snowflake Source
+### Snowflake Source (Password Authentication)
 
 ```hcl
 resource "census_source" "warehouse" {
@@ -19,6 +19,27 @@ resource "census_source" "warehouse" {
     username       = "census_user"
     password       = var.snowflake_password
     role           = "CENSUS_ROLE"
+  })
+}
+```
+
+### Snowflake Source (Keypair Authentication)
+
+```hcl
+resource "census_source" "warehouse_keypair" {
+  workspace_id = census_workspace.main.id
+  name         = "Production Warehouse (Keypair)"
+  type         = "snowflake"
+
+  connection_config = jsonencode({
+    account              = "abc12345.us-east-1"
+    warehouse            = "COMPUTE_WH"
+    database             = "PRODUCTION"
+    username             = "census_user"
+    role                 = "CENSUS_ROLE"
+    use_keypair          = true
+    private_key_pkcs8    = var.snowflake_private_key
+    private_key_passphrase = var.snowflake_key_passphrase  # Optional, omit if key is not encrypted
   })
 }
 ```

--- a/examples/complete-census-setup/main.tf
+++ b/examples/complete-census-setup/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     census = {
       source  = "sutrolabs/census"
-      version = "~> 0.1.0"
+      version = "~> 0.2.0"
     }
   }
 }


### PR DESCRIPTION
## Problem

Users reported being unable to create Snowflake sources with keypair authentication through Terraform. The provider validation was incorrectly requiring the `password` field even when `use_keypair=true` was set.

The Census API works correctly via direct API calls, but Terraform would fail with:
```
Error: source credential validation failed: required field 'password' (Password) is missing
```

## Root Cause

The Census `/source_types` API returns field metadata with `show.unless` conditions to express mutually exclusive authentication methods:

```json
{
  "id": "password",
  "rules": ["required"],
  "show": {
    "unless": {
      "use_keypair": {"eq": true}
    }
  }
}
```

The provider's `ValidateSourceCredentials` function only handled `show.if` conditions, not `show.unless` conditions, causing it to miss the mutual exclusion logic.

## Solution

Added support for `show.unless` conditions in the credential validation logic (`census/client/source.go`). The implementation:
- Handles nested condition structures with `eq` operators
- Supports both boolean and string boolean values ("true", "1")
- Works with any field, not just Snowflake-specific logic

## Changes

- ✅ Add `show.unless` condition handling to `ValidateSourceCredentials`
- ✅ Add Snowflake keypair authentication example to documentation
- ✅ Add comprehensive unit tests (4 new test cases, all passing)
- ✅ Update CHANGELOG.md
- ✅ Update example to use v0.2.0

## Testing

All unit tests pass:
- `TestValidateSourceCredentials_SnowflakePassword` - Existing password auth still works
- `TestValidateSourceCredentials_SnowflakeKeypair` - New keypair auth works with both boolean types
- `TestValidateSourceCredentials_ShowIfCondition` - Regression test for existing `show.if` logic
- `TestValidateSourceCredentials_UnknownSourceType` - Error handling

## Example Usage

Users can now provision Snowflake sources with keypair authentication:

```hcl
resource "census_source" "warehouse_keypair" {
  workspace_id = census_workspace.main.id
  name         = "Production Warehouse"
  type         = "snowflake"

  connection_config = jsonencode({
    account                = "abc12345.us-east-1"
    warehouse              = "COMPUTE_WH"
    database               = "PRODUCTION"
    username               = "census_user"
    role                   = "CENSUS_ROLE"
    use_keypair            = true
    private_key_pkcs8      = var.snowflake_private_key
    private_key_passphrase = var.snowflake_key_passphrase  # Optional
  })
}
```