### PR TITLE
Fix example resources in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **[PLANNED]** Migrate `field_mapping` from TypeList to TypeSet for true order independence. This will cause a one-time diff showing all mappings as "replaced" during upgrade, but eliminates all future order-related drift. The migration is automatic and safe - mappings are keyed by destination field ("to") which is unique per sync. Users will see a large but harmless diff on first upgrade.
 
+## [0.2.7] - 2025-12-16
+
+### Removed
+- **BREAKING**: Removed `type = "hash"` as a valid field mapping type. This option was never implemented in the Census API and had no functional effect (it was treated identically to `type = "direct"`). Any configurations using `type = "hash"` should be changed to `type = "direct"` or simply omit the type field (direct is the default).
+
+### Fixed
+- **Documentation**: Fixed extensive drift in resource documentation where examples didn't match actual provider implementation:
+  - **sync resource**: Fixed all examples to use correct block syntax instead of `jsonencode()`, changed `name` to `label`, fixed `destination_object` to `destination_attributes` block, fixed `field_mapping` and `alert` from array syntax to multiple blocks
+  - **destination resource**: Fixed field references from `credentials` to `connection_config`, updated exported attributes from `connection_status` to `status` and `test_status`
+  - **source resource**: Fixed field references from `credentials` to `connection_config`, updated exported attributes from `connection_status` to `status` and `test_status`
+  - Added Google Sheets sync example demonstrating mirror operation with auto-mapping
+
 ## [0.2.6] - 2025-12-16
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 BINARY_NAME=terraform-provider-census
-VERSION=0.2.4
+VERSION=0.2.7
 BUILD_DIR=bin
 LDFLAGS=-ldflags "-X main.version=${VERSION}"
 

--- a/census/provider/data_source_sync.go
+++ b/census/provider/data_source_sync.go
@@ -90,7 +90,7 @@ func dataSourceSync() *schema.Resource {
 						"operation": {
 							Type:        schema.TypeString,
 							Computed:    true,
-							Description: "Mapping operation (direct, hash, etc.).",
+							Description: "Mapping operation (direct, constant, sync_metadata, segment_membership, liquid_template).",
 						},
 						"constant": {
 							Type:        schema.TypeString,

--- a/census/provider/resource_sync.go
+++ b/census/provider/resource_sync.go
@@ -148,9 +148,9 @@ func syncSchemaMap(alertCollectionType schema.ValueType) map[string]*schema.Sche
 						Type:        schema.TypeString,
 						Optional:    true,
 						Default:     "direct",
-						Description: "Mapping type: 'direct' (default), 'hash', 'constant', 'sync_metadata', 'segment_membership', or 'liquid_template'.",
+						Description: "Mapping type: 'direct' (default), 'constant', 'sync_metadata', 'segment_membership', or 'liquid_template'.",
 						ValidateFunc: validation.StringInSlice([]string{
-							"direct", "hash", "constant", "sync_metadata", "segment_membership", "liquid_template",
+							"direct", "constant", "sync_metadata", "segment_membership", "liquid_template",
 						}, false),
 					},
 					"constant": {
@@ -1871,7 +1871,7 @@ func ConvertFieldMappingsToMappingAttributes(fieldMappings []client.FieldMapping
 			}
 
 		default:
-			// Default to column mapping (direct or hash)
+			// Default to column mapping (direct)
 			mappingFrom = client.MappingFrom{
 				Type: "column",
 				Data: fm.From,

--- a/docs/resources/destination.md
+++ b/docs/resources/destination.md
@@ -68,7 +68,8 @@ resource "census_destination" "intercom" {
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the destination.
-* `connection_status` - The current connection status of the destination.
+* `status` - The current status of the destination.
+* `test_status` - The test status of the destination connection.
 
 ## Import
 
@@ -86,6 +87,6 @@ terraform import census_destination.salesforce "12345:67890"
 
 ## Notes
 
-* The `credentials` field is marked as sensitive and will not be displayed in Terraform output.
+* The `connection_config` field is marked as sensitive and will not be displayed in Terraform output.
 * Destination types and required credential fields are validated against the Census API's `/connectors` endpoint.
 * The provider automatically refreshes destination metadata after creation to discover available objects.

--- a/docs/resources/source.md
+++ b/docs/resources/source.md
@@ -97,7 +97,8 @@ resource "census_source" "postgres" {
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the source.
-* `connection_status` - The current connection status of the source.
+* `status` - The current status of the source.
+* `test_status` - The test status of the source connection.
 
 ## Import
 
@@ -115,6 +116,6 @@ terraform import census_source.warehouse "12345:67890"
 
 ## Notes
 
-* The `credentials` field is marked as sensitive and will not be displayed in Terraform output.
+* The `connection_config` field is marked as sensitive and will not be displayed in Terraform output.
 * Source types and required credential fields are validated against the Census API's `/source_types` endpoint.
 * After creation, the provider automatically triggers a table refresh to discover available tables.

--- a/docs/resources/sync.md
+++ b/docs/resources/sync.md
@@ -14,8 +14,10 @@ resource "census_sync" "user_sync" {
   source_attributes {
     connection_id = census_source.warehouse.id
     object {
-      type       = "table"
-      table_name = "users"
+      type          = "table"
+      table_name    = "users"
+      table_schema  = "demo"
+      table_catalog = "dev"
     }
   }
 
@@ -162,8 +164,10 @@ resource "census_sync" "tagged_sync" {
   source_attributes {
     connection_id = census_source.warehouse.id
     object {
-      type       = "table"
-      table_name = "users"
+      type          = "table"
+      table_name    = "users"
+      table_schema  = "demo"
+      table_catalog = "dev"
     }
   }
 
@@ -198,8 +202,10 @@ resource "census_sync" "metadata_sync" {
   source_attributes {
     connection_id = census_source.warehouse.id
     object {
-      type       = "table"
-      table_name = "users"
+      type          = "table"
+      table_name    = "users"
+      table_schema  = "demo"
+      table_catalog = "dev"
     }
   }
 
@@ -240,8 +246,10 @@ resource "census_sync" "segment_sync" {
   source_attributes {
     connection_id = census_source.warehouse.id
     object {
-      type       = "table"
-      table_name = "users"
+      type          = "table"
+      table_name    = "users"
+      table_schema  = "demo"
+      table_catalog = "dev"
     }
   }
 
@@ -277,8 +285,10 @@ resource "census_sync" "template_sync" {
   source_attributes {
     connection_id = census_source.warehouse.id
     object {
-      type       = "table"
-      table_name = "users"
+      type          = "table"
+      table_name    = "users"
+      table_schema  = "demo"
+      table_catalog = "dev"
     }
   }
 
@@ -319,8 +329,10 @@ resource "census_sync" "auto_sync" {
   source_attributes {
     connection_id = census_source.warehouse.id
     object {
-      type       = "table"
-      table_name = "users"
+      type          = "table"
+      table_name    = "users"
+      table_schema  = "demo"
+      table_catalog = "dev"
     }
   }
 
@@ -367,9 +379,9 @@ resource "census_sync" "sheets_sync" {
     connection_id = census_source.warehouse.id
     object {
       type          = "table"
-      table_name    = "analytics_summary"
-      table_schema  = "public"
-      table_catalog = "production"
+      table_name    = "users"
+      table_schema  = "demo"
+      table_catalog = "dev"
     }
   }
 
@@ -408,8 +420,10 @@ resource "census_sync" "user_list_sync" {
   source_attributes {
     connection_id = census_source.warehouse.id
     object {
-      type       = "table"
-      table_name = "users"
+      type          = "table"
+      table_name    = "users"
+      table_schema  = "demo"
+      table_catalog = "dev"
     }
   }
 
@@ -506,8 +520,10 @@ resource "census_sync" "monitored_sync" {
   source_attributes {
     connection_id = census_source.warehouse.id
     object {
-      type       = "table"
-      table_name = "customers"
+      type          = "table"
+      table_name    = "users"
+      table_schema  = "demo"
+      table_catalog = "dev"
     }
   }
 
@@ -592,8 +608,10 @@ resource "census_sync" "mirror_sync" {
   source_attributes {
     connection_id = census_source.warehouse.id
     object {
-      type       = "table"
-      table_name = "products"
+      type          = "table"
+      table_name    = "users"
+      table_schema  = "demo"
+      table_catalog = "dev"
     }
   }
 
@@ -638,8 +656,10 @@ resource "census_sync" "incremental_append" {
   source_attributes {
     connection_id = census_source.warehouse.id
     object {
-      type       = "table"
-      table_name = "event_logs"
+      type          = "table"
+      table_name    = "users"
+      table_schema  = "demo"
+      table_catalog = "dev"
     }
   }
 
@@ -692,8 +712,10 @@ resource "census_sync" "preserve_example" {
   source_attributes {
     connection_id = census_source.warehouse.id
     object {
-      type       = "table"
-      table_name = "customers"
+      type          = "table"
+      table_name    = "users"
+      table_schema  = "demo"
+      table_catalog = "dev"
     }
   }
 

--- a/docs/resources/sync.md
+++ b/docs/resources/sync.md
@@ -8,34 +8,37 @@ Manages a Census sync that moves data from a source (table, dataset, model, etc.
 
 ```hcl
 resource "census_sync" "user_sync" {
-  workspace_id   = census_workspace.main.id
-  name           = "Users to Salesforce"
+  workspace_id = census_workspace.main.id
+  label        = "Users to Salesforce"
 
-  source_attributes = jsonencode({
+  source_attributes {
     connection_id = census_source.warehouse.id
-    object = {
+    object {
       type       = "table"
       table_name = "users"
     }
-  })
+  }
 
-  destination_object = "Contact"
+  destination_attributes {
+    connection_id = census_destination.salesforce.id
+    object        = "Contact"
+  }
 
-  field_mapping = [
-    {
-      from                  = "email"
-      to                    = "Email"
-      is_primary_identifier = true
-    },
-    {
-      from = "first_name"
-      to   = "FirstName"
-    },
-    {
-      from = "last_name"
-      to   = "LastName"
-    },
-  ]
+  field_mapping {
+    from                  = "email"
+    to                    = "Email"
+    is_primary_identifier = true
+  }
+
+  field_mapping {
+    from = "first_name"
+    to   = "FirstName"
+  }
+
+  field_mapping {
+    from = "last_name"
+    to   = "LastName"
+  }
 
   operation = "upsert"
 
@@ -55,30 +58,32 @@ resource "census_sync" "user_sync" {
 
 ```hcl
 resource "census_sync" "high_value_sync" {
-  workspace_id   = census_workspace.main.id
-  name           = "High Value Customers to HubSpot"
+  workspace_id = census_workspace.main.id
+  label        = "High Value Customers to HubSpot"
 
-  source_attributes = jsonencode({
+  source_attributes {
     connection_id = census_source.warehouse.id
-    object = {
+    object {
       type = "dataset"
       id   = census_dataset.high_value_customers.id
     }
-  })
+  }
 
-  destination_object = "contacts"
+  destination_attributes {
+    connection_id = census_destination.hubspot.id
+    object        = "contacts"
+  }
 
-  field_mapping = [
-    {
-      from                  = "email"
-      to                    = "email"
-      is_primary_identifier = true
-    },
-    {
-      from = "lifetime_value"
-      to   = "lifetime_value"
-    },
-  ]
+  field_mapping {
+    from                  = "email"
+    to                    = "email"
+    is_primary_identifier = true
+  }
+
+  field_mapping {
+    from = "lifetime_value"
+    to   = "lifetime_value"
+  }
 
   operation = "upsert"
 
@@ -99,15 +104,15 @@ resource "census_sync" "high_value_sync" {
 
 ```hcl
 resource "census_sync" "vip_segment_sync" {
-  workspace_id   = census_workspace.main.id
-  name           = "VIP Users Segment to Salesforce"
+  workspace_id = census_workspace.main.id
+  label        = "VIP Users Segment to Salesforce"
 
   source_attributes {
-    connection_id     = 829
-    filter_segment_id = 3060  # The segment ID
+    connection_id = 829
     object {
-      type = "dataset"
-      id   = "5951"  # The dataset ID that the segment belongs to
+      type       = "segment"
+      id         = "3060"      # The segment ID
+      dataset_id = "5951"      # The dataset ID that the segment belongs to
     }
   }
 
@@ -116,21 +121,21 @@ resource "census_sync" "vip_segment_sync" {
     object        = "Contact"
   }
 
-  field_mapping = [
-    {
-      from                  = "email"
-      to                    = "Email"
-      is_primary_identifier = true
-    },
-    {
-      from = "first_name"
-      to   = "FirstName"
-    },
-    {
-      from = "last_name"
-      to   = "LastName"
-    },
-  ]
+  field_mapping {
+    from                  = "email"
+    to                    = "Email"
+    is_primary_identifier = true
+  }
+
+  field_mapping {
+    from = "first_name"
+    to   = "FirstName"
+  }
+
+  field_mapping {
+    from = "last_name"
+    to   = "LastName"
+  }
 
   operation = "upsert"
 
@@ -147,69 +152,37 @@ resource "census_sync" "vip_segment_sync" {
 }
 ```
 
-### Sync with Hash Operation
-
-```hcl
-resource "census_sync" "secure_sync" {
-  workspace_id   = census_workspace.main.id
-  name           = "Hashed Email Sync"
-
-  source_attributes = jsonencode({
-    connection_id = census_source.warehouse.id
-    object = {
-      type       = "table"
-      table_name = "users"
-    }
-  })
-
-  destination_object = "user"
-
-  field_mapping = [
-    {
-      from                  = "id"
-      to                    = "userId"
-      is_primary_identifier = true
-    },
-    {
-      from = "email"
-      to   = "email_hash"
-      type = "hash"
-    },
-  ]
-
-  operation = "upsert"
-}
-```
-
 ### Sync with Constant Value
 
 ```hcl
 resource "census_sync" "tagged_sync" {
-  workspace_id   = census_workspace.main.id
-  name           = "Tagged Contact Sync"
+  workspace_id = census_workspace.main.id
+  label        = "Tagged Contact Sync"
 
-  source_attributes = jsonencode({
+  source_attributes {
     connection_id = census_source.warehouse.id
-    object = {
+    object {
       type       = "table"
       table_name = "users"
     }
-  })
+  }
 
-  destination_object = "Contact"
+  destination_attributes {
+    connection_id = census_destination.salesforce.id
+    object        = "Contact"
+  }
 
-  field_mapping = [
-    {
-      from                  = "email"
-      to                    = "Email"
-      is_primary_identifier = true
-    },
-    {
-      type     = "constant"
-      constant = "Terraform Managed"
-      to       = "LeadSource"
-    },
-  ]
+  field_mapping {
+    from                  = "email"
+    to                    = "Email"
+    is_primary_identifier = true
+  }
+
+  field_mapping {
+    type     = "constant"
+    constant = "Terraform Managed"
+    to       = "LeadSource"
+  }
 
   operation = "upsert"
 }
@@ -219,36 +192,39 @@ resource "census_sync" "tagged_sync" {
 
 ```hcl
 resource "census_sync" "metadata_sync" {
-  workspace_id   = census_workspace.main.id
-  name           = "Sync with Metadata Tracking"
+  workspace_id = census_workspace.main.id
+  label        = "Sync with Metadata Tracking"
 
-  source_attributes = jsonencode({
+  source_attributes {
     connection_id = census_source.warehouse.id
-    object = {
+    object {
       type       = "table"
       table_name = "users"
     }
-  })
+  }
 
-  destination_object = "Contact"
+  destination_attributes {
+    connection_id = census_destination.salesforce.id
+    object        = "Contact"
+  }
 
-  field_mapping = [
-    {
-      from                  = "email"
-      to                    = "Email"
-      is_primary_identifier = true
-    },
-    {
-      from = "first_name"
-      to   = "FirstName"
-    },
-    {
-      # Map Census sync_run_id to a custom field
-      type             = "sync_metadata"
-      sync_metadata_key = "sync_run_id"
-      to               = "Last_Sync_Run_ID__c"
-    },
-  ]
+  field_mapping {
+    from                  = "email"
+    to                    = "Email"
+    is_primary_identifier = true
+  }
+
+  field_mapping {
+    from = "first_name"
+    to   = "FirstName"
+  }
+
+  field_mapping {
+    # Map Census sync_run_id to a custom field
+    type              = "sync_metadata"
+    sync_metadata_key = "sync_run_id"
+    to                = "Last_Sync_Run_ID__c"
+  }
 
   operation = "upsert"
 }
@@ -258,32 +234,34 @@ resource "census_sync" "metadata_sync" {
 
 ```hcl
 resource "census_sync" "segment_sync" {
-  workspace_id   = census_workspace.main.id
-  name           = "Sync with Segment Data"
+  workspace_id = census_workspace.main.id
+  label        = "Sync with Segment Data"
 
-  source_attributes = jsonencode({
+  source_attributes {
     connection_id = census_source.warehouse.id
-    object = {
+    object {
       type       = "table"
       table_name = "users"
     }
-  })
+  }
 
-  destination_object = "Contact"
+  destination_attributes {
+    connection_id = census_destination.salesforce.id
+    object        = "Contact"
+  }
 
-  field_mapping = [
-    {
-      from                  = "email"
-      to                    = "Email"
-      is_primary_identifier = true
-    },
-    {
-      # Map segment membership information
-      type              = "segment_membership"
-      segment_identify_by = "name"
-      to                = "Active_Segments__c"
-    },
-  ]
+  field_mapping {
+    from                  = "email"
+    to                    = "Email"
+    is_primary_identifier = true
+  }
+
+  field_mapping {
+    # Map segment membership information
+    type                = "segment_membership"
+    segment_identify_by = "name"
+    to                  = "Active_Segments__c"
+  }
 
   operation = "upsert"
 }
@@ -293,36 +271,39 @@ resource "census_sync" "segment_sync" {
 
 ```hcl
 resource "census_sync" "template_sync" {
-  workspace_id   = census_workspace.main.id
-  name           = "Sync with Field Transformations"
+  workspace_id = census_workspace.main.id
+  label        = "Sync with Field Transformations"
 
-  source_attributes = jsonencode({
+  source_attributes {
     connection_id = census_source.warehouse.id
-    object = {
+    object {
       type       = "table"
       table_name = "users"
     }
-  })
+  }
 
-  destination_object = "Contact"
+  destination_attributes {
+    connection_id = census_destination.salesforce.id
+    object        = "Contact"
+  }
 
-  field_mapping = [
-    {
-      from                  = "email"
-      to                    = "Email"
-      is_primary_identifier = true
-    },
-    {
-      from = "first_name"
-      to   = "FirstName"
-    },
-    {
-      # Use Liquid template to transform data
-      type           = "liquid_template"
-      liquid_template = "{{ record['status'] | upcase }}"
-      to             = "Account_Status__c"
-    },
-  ]
+  field_mapping {
+    from                  = "email"
+    to                    = "Email"
+    is_primary_identifier = true
+  }
+
+  field_mapping {
+    from = "first_name"
+    to   = "FirstName"
+  }
+
+  field_mapping {
+    # Use Liquid template to transform data
+    type            = "liquid_template"
+    liquid_template = "{{ record['status'] | upcase }}"
+    to              = "Account_Status__c"
+  }
 
   operation = "upsert"
 }
@@ -332,18 +313,21 @@ resource "census_sync" "template_sync" {
 
 ```hcl
 resource "census_sync" "auto_sync" {
-  workspace_id   = census_workspace.main.id
-  name           = "Auto-Mapped Users Sync"
+  workspace_id = census_workspace.main.id
+  label        = "Auto-Mapped Users Sync"
 
-  source_attributes = jsonencode({
+  source_attributes {
     connection_id = census_source.warehouse.id
-    object = {
+    object {
       type       = "table"
       table_name = "users"
     }
-  })
+  }
 
-  destination_object = "Contact"
+  destination_attributes {
+    connection_id = census_destination.salesforce.id
+    object        = "Contact"
+  }
 
   # Automatically sync all properties from source to destination
   field_behavior      = "sync_all_properties"
@@ -351,13 +335,11 @@ resource "census_sync" "auto_sync" {
   field_order         = "mapping_order"
 
   # Only need to define the primary identifier when using sync_all_properties
-  field_mapping = [
-    {
-      from                  = "email"
-      to                    = "Email"
-      is_primary_identifier = true
-    },
-  ]
+  field_mapping {
+    from                  = "email"
+    to                    = "Email"
+    is_primary_identifier = true
+  }
 
   operation = "upsert"
 
@@ -374,39 +356,83 @@ resource "census_sync" "auto_sync" {
 }
 ```
 
+### Sync to Google Sheets (Mirror with Auto-Mapping)
+
+```hcl
+resource "census_sync" "sheets_sync" {
+  workspace_id = census_workspace.main.id
+  label        = "Data Export to Google Sheets"
+
+  source_attributes {
+    connection_id = census_source.warehouse.id
+    object {
+      type          = "table"
+      table_name    = "analytics_summary"
+      table_schema  = "public"
+      table_catalog = "production"
+    }
+  }
+
+  destination_attributes {
+    connection_id = census_destination.google_sheets.id
+    # Google Sheets object format: JSON with spreadsheet_id and sheet_id
+    object        = "{\"spreadsheet_id\":\"1r9HavWIo-CS14sblFl-Kxa2kVbMGlqWIBDU6Hb_W8sA\",\"sheet_id\":0}"
+  }
+
+  operation = "mirror"
+
+  # Automatically sync all properties - no primary identifier needed for Google Sheets mirror
+  field_behavior = "sync_all_properties"
+  field_normalization = "match_source_names"
+
+  run_mode {
+    type = "triggered"
+    triggers {
+      schedule {
+        frequency = "daily"
+        hour      = 6
+        minute    = 0
+      }
+    }
+  }
+}
+```
+
 ### Sync with Lookup Field (Foreign Key Relationship)
 
 ```hcl
 resource "census_sync" "user_list_sync" {
-  workspace_id   = census_workspace.main.id
-  name           = "Users to Google Ads Customer Match"
+  workspace_id = census_workspace.main.id
+  label        = "Users to Google Ads Customer Match"
 
-  source_attributes = jsonencode({
+  source_attributes {
     connection_id = census_source.warehouse.id
-    object = {
+    object {
       type       = "table"
       table_name = "users"
     }
-  })
+  }
 
-  destination_object = "user_data"
+  destination_attributes {
+    connection_id = census_destination.google_ads.id
+    object        = "user_data"
+  }
 
-  field_mapping = [
-    {
-      from                  = "email"
-      to                    = "user_identifier.hashed_email"
-      is_primary_identifier = true
-    },
-    {
-      # Map a constant value to user_list_id via lookup
-      # This looks up the user_list record where id = "6600827417"
-      type          = "constant"
-      constant      = "6600827417"
-      to            = "user_list_id"
-      lookup_object = "user_list"
-      lookup_field  = "id"
-    },
-  ]
+  field_mapping {
+    from                  = "email"
+    to                    = "user_identifier.hashed_email"
+    is_primary_identifier = true
+  }
+
+  field_mapping {
+    # Map a constant value to user_list_id via lookup
+    # This looks up the user_list record where id = "6600827417"
+    type          = "constant"
+    constant      = "6600827417"
+    to            = "user_list_id"
+    lookup_object = "user_list"
+    lookup_field  = "id"
+  }
 
   operation = "mirror"
 
@@ -426,28 +452,29 @@ resource "census_sync" "user_list_sync" {
 
 ```hcl
 resource "census_sync" "blob_storage_sync" {
-  workspace_id   = census_workspace.main.id
-  name           = "Users to Azure Blob Storage"
+  workspace_id = census_workspace.main.id
+  label        = "Users to Azure Blob Storage"
 
-  source_attributes = jsonencode({
+  source_attributes {
     connection_id = census_source.warehouse.id
-    object = {
-      type  = "model"
-      id    = "21130"
+    object {
+      type = "model"
+      id   = "21130"
     }
-  })
+  }
 
-  destination_object = "path_to_file/data_%m-%d-%y.parquet"
+  destination_attributes {
+    connection_id = census_destination.azure_blob.id
+    object        = "path_to_file/data_%m-%d-%y.parquet"
+  }
 
-  field_mapping = [
-    {
-      from = "email"
-      to   = "EMAIL"
-    },
-  ]
+  field_mapping {
+    from = "email"
+    to   = "EMAIL"
+  }
 
-  operation     = "mirror"
-  field_behavior = "sync_all_properties"
+  operation           = "mirror"
+  field_behavior      = "sync_all_properties"
   field_normalization = "match_source_names"
 
   # Advanced configuration for file export
@@ -473,72 +500,75 @@ resource "census_sync" "blob_storage_sync" {
 
 ```hcl
 resource "census_sync" "monitored_sync" {
-  workspace_id   = census_workspace.main.id
-  name           = "High-Priority Customer Sync with Alerts"
+  workspace_id = census_workspace.main.id
+  label        = "High-Priority Customer Sync with Alerts"
 
-  source_attributes = jsonencode({
+  source_attributes {
     connection_id = census_source.warehouse.id
-    object = {
+    object {
       type       = "table"
       table_name = "customers"
     }
-  })
+  }
 
-  destination_object = "Contact"
+  destination_attributes {
+    connection_id = census_destination.salesforce.id
+    object        = "Contact"
+  }
 
-  field_mapping = [
-    {
-      from                  = "email"
-      to                    = "Email"
-      is_primary_identifier = true
-    },
-    {
-      from = "name"
-      to   = "Name"
-    },
-  ]
+  field_mapping {
+    from                  = "email"
+    to                    = "Email"
+    is_primary_identifier = true
+  }
+
+  field_mapping {
+    from = "name"
+    to   = "Name"
+  }
 
   operation = "upsert"
 
   # Configure multiple alerts
-  alert = [
-    {
-      # Alert when sync fails completely
-      type                 = "FailureAlertConfiguration"
-      send_for             = "first_time"
-      should_send_recovery = true
-      options              = {}
-    },
-    {
-      # Alert when more than 50% of records are invalid
-      type                 = "InvalidRecordPercentAlertConfiguration"
-      send_for             = "every_time"
-      should_send_recovery = true
-      options = {
-        threshold = "50"
-      }
-    },
-    {
-      # Alert when sync runtime exceeds 30 minutes
-      type                 = "RuntimeAlertConfiguration"
-      send_for             = "first_time"
-      should_send_recovery = false
-      options = {
-        threshold  = "30"
-        unit       = "minutes"
-        start_type = "actual"
-      }
-    },
-    {
-      # Alert on sync completion
-      type                 = "StatusAlertConfiguration"
-      send_for             = "every_time"
-      should_send_recovery = false
-      options = {
-        status_name = "completed"
-      }
-    },
-  ]
+  alert {
+    # Alert when sync fails completely
+    type                 = "FailureAlertConfiguration"
+    send_for             = "first_time"
+    should_send_recovery = true
+    options              = {}
+  }
+
+  alert {
+    # Alert when more than 50% of records are invalid
+    type                 = "InvalidRecordPercentAlertConfiguration"
+    send_for             = "every_time"
+    should_send_recovery = true
+    options = {
+      threshold = "50"
+    }
+  }
+
+  alert {
+    # Alert when sync runtime exceeds 30 minutes
+    type                 = "RuntimeAlertConfiguration"
+    send_for             = "first_time"
+    should_send_recovery = false
+    options = {
+      threshold  = "30"
+      unit       = "minutes"
+      start_type = "actual"
+    }
+  }
+
+  alert {
+    # Alert on sync completion
+    type                 = "StatusAlertConfiguration"
+    send_for             = "every_time"
+    should_send_recovery = false
+    options = {
+      status_name = "completed"
+    }
+  }
 
   run_mode {
     type = "triggered"
@@ -556,30 +586,32 @@ resource "census_sync" "monitored_sync" {
 
 ```hcl
 resource "census_sync" "mirror_sync" {
-  workspace_id   = census_workspace.main.id
-  name           = "Product Catalog Mirror"
+  workspace_id = census_workspace.main.id
+  label        = "Product Catalog Mirror"
 
-  source_attributes = jsonencode({
+  source_attributes {
     connection_id = census_source.warehouse.id
-    object = {
+    object {
       type       = "table"
       table_name = "products"
     }
-  })
+  }
 
-  destination_object = "Product2"
+  destination_attributes {
+    connection_id = census_destination.salesforce.id
+    object        = "Product2"
+  }
 
-  field_mapping = [
-    {
-      from                  = "product_id"
-      to                    = "ProductCode"
-      is_primary_identifier = true
-    },
-    {
-      from = "name"
-      to   = "Name"
-    },
-  ]
+  field_mapping {
+    from                  = "product_id"
+    to                    = "ProductCode"
+    is_primary_identifier = true
+  }
+
+  field_mapping {
+    from = "name"
+    to   = "Name"
+  }
 
   operation = "mirror"
 
@@ -600,34 +632,37 @@ resource "census_sync" "mirror_sync" {
 
 ```hcl
 resource "census_sync" "incremental_append" {
-  workspace_id   = census_workspace.main.id
-  name           = "Incremental Event Log Sync"
+  workspace_id = census_workspace.main.id
+  label        = "Incremental Event Log Sync"
 
-  source_attributes = jsonencode({
+  source_attributes {
     connection_id = census_source.warehouse.id
-    object = {
+    object {
       type       = "table"
       table_name = "event_logs"
     }
-  })
+  }
 
-  destination_object = "Event__c"
+  destination_attributes {
+    connection_id = census_destination.salesforce.id
+    object        = "Event__c"
+  }
 
-  field_mapping = [
-    {
-      from                  = "event_id"
-      to                    = "Event_ID__c"
-      is_primary_identifier = true
-    },
-    {
-      from = "event_name"
-      to   = "Name"
-    },
-    {
-      from = "updated_at"
-      to   = "Updated_At__c"
-    },
-  ]
+  field_mapping {
+    from                  = "event_id"
+    to                    = "Event_ID__c"
+    is_primary_identifier = true
+  }
+
+  field_mapping {
+    from = "event_name"
+    to   = "Name"
+  }
+
+  field_mapping {
+    from = "updated_at"
+    to   = "Updated_At__c"
+  }
 
   operation = "append"
 
@@ -651,43 +686,47 @@ resource "census_sync" "incremental_append" {
 
 ```hcl
 resource "census_sync" "preserve_example" {
-  workspace_id   = census_workspace.main.id
-  name           = "Customer Sync with Field Preservation"
+  workspace_id = census_workspace.main.id
+  label        = "Customer Sync with Field Preservation"
 
-  source_attributes = jsonencode({
+  source_attributes {
     connection_id = census_source.warehouse.id
-    object = {
+    object {
       type       = "table"
       table_name = "customers"
     }
-  })
+  }
 
-  destination_object = "Contact"
+  destination_attributes {
+    connection_id = census_destination.salesforce.id
+    object        = "Contact"
+  }
 
-  field_mapping = [
-    {
-      from                  = "email"
-      to                    = "Email"
-      is_primary_identifier = true
-    },
-    {
-      from = "first_name"
-      to   = "FirstName"
-    },
-    {
-      # Don't overwrite existing phone numbers in destination
-      from            = "phone"
-      to              = "Phone"
-      preserve_values = true
-      sync_null_values = false  # Don't sync null phone values
-    },
-    {
-      # Generate a custom field in the destination
-      from           = "customer_tier"
-      to             = "Customer_Tier__c"
-      generate_field = true
-    },
-  ]
+  field_mapping {
+    from                  = "email"
+    to                    = "Email"
+    is_primary_identifier = true
+  }
+
+  field_mapping {
+    from = "first_name"
+    to   = "FirstName"
+  }
+
+  field_mapping {
+    # Don't overwrite existing phone numbers in destination
+    from             = "phone"
+    to               = "Phone"
+    preserve_values  = true # Don't overwrite existing data in the destination
+    sync_null_values = false  # Don't sync null phone values
+  }
+
+  field_mapping {
+    # Generate a custom field in the destination
+    from           = "customer_tier"
+    to             = "Customer_Tier__c"
+    generate_field = true
+  }
 
   operation = "upsert"
 
@@ -707,23 +746,23 @@ resource "census_sync" "preserve_example" {
 ## Argument Reference
 
 * `workspace_id` - (Required, Forces new resource) The ID of the workspace this sync belongs to.
-* `name` - (Required) The name of the sync.
-* `source_attributes` - (Required) Configuration block for the source. Must include:
+* `label` - (Required) The label of the sync.
+* `source_attributes` - (Required) Configuration block for the source. Block contains:
   * `connection_id` - (Required) The source connection ID
-  * `filter_segment_id` - (Optional) The filter segment ID. When using a segment source, set this to the segment ID and set `object.type` to `"dataset"` with `object.id` as the dataset ID that the segment belongs to.
   * `object` - (Required) Object configuration block:
     * `type` - (Required) Source type: `"table"`, `"dataset"`, `"model"`, `"topic"`, `"segment"`, or `"cohort"`
-    * For table sources: `table_name`, optionally `table_schema` and `table_catalog`
-    * For dataset/model/segment sources: `id` of the dataset/model
-    * For segment sources specifically: use `type="dataset"` and provide the dataset `id`, then specify the segment via the top-level `filter_segment_id` field
+    * For table sources: `table_name`, `table_schema`, and `table_catalog`
+    * For dataset/model sources: `id` of the dataset/model
+    * For segment sources: use `type="segment"`, provide the segment `id`, and specify `dataset_id` for the dataset the segment belongs to
+    * For cohort sources: use `type="cohort"`, provide the cohort `id`, and specify `dataset_id` for the dataset the cohort belongs to
 * `destination_attributes` - (Required) Destination configuration block:
   * `connection_id` - (Required) The destination connection ID
   * `object` - (Required) The destination object name (e.g., "Contact" for Salesforce, "contacts" for HubSpot)
   * `lead_union_insert_to` - (Optional) Where to insert a union object (for Salesforce connections only)
-* `field_mapping` - (Optional) Set of field mappings between source and destination. Each mapping includes:
-  * `from` - Source field name (required for `type="direct"` or `type="hash"`). Omit for `constant`, `sync_metadata`, `segment_membership`, and `liquid_template` mappings.
+* `field_mapping` - (Optional) Field mappings between source and destination. Define multiple `field_mapping` blocks for multiple mappings. Each mapping block includes:
+  * `from` - Source field name (required for `type="direct"`). Omit for `constant`, `sync_metadata`, `segment_membership`, and `liquid_template` mappings.
   * `to` - Destination field name (required)
-  * `type` - Mapping type: `"direct"` (default), `"hash"`, `"constant"`, `"sync_metadata"`, `"segment_membership"`, or `"liquid_template"`.
+  * `type` - Mapping type: `"direct"` (default), `"constant"`, `"sync_metadata"`, `"segment_membership"`, or `"liquid_template"`.
   * `constant` - Constant value (must also set `type="constant"`)
   * `sync_metadata_key` - Sync metadata key (e.g., `"sync_run_id"`). Must also set `type="sync_metadata"`.
   * `segment_identify_by` - How to identify segments (e.g., `"name"`). Must also set `type="segment_membership"`.
@@ -763,7 +802,7 @@ resource "census_sync" "preserve_example" {
   * `"sync_updates_and_deletes"` - Incrementally syncs changes by inserting new records, updating modified records, and deleting records that no longer exist in the source. This is the most common and efficient strategy for keeping destinations in sync (default).
   * `"sync_updates_and_nulls"` - Updates existing records and sets fields to null when the source contains null values, without performing deletes.
   * `"upload_and_swap"` - Replaces the entire destination table with the current source snapshot. Useful for destinations that don't support incremental updates or when you need a complete refresh.
-* `alert` - (Optional) Set of alert configurations for monitoring sync health. Multiple alerts can be configured. Each alert includes:
+* `alert` - (Optional) Alert configurations for monitoring sync health. Define multiple `alert` blocks to configure multiple alerts. Each alert block includes:
   * `type` - (Required) Type of alert. Valid values:
     * `"FailureAlertConfiguration"` - Alert when sync fails completely
     * `"InvalidRecordPercentAlertConfiguration"` - Alert when invalid/rejected records exceed threshold
@@ -829,11 +868,13 @@ terraform import census_sync.user_sync "12345:67890"
 
 ## Notes
 
-* Field mappings use TypeSet to prevent drift from ordering changes returned by the API.
-* The `source_attributes` structure must be OpenAPI compliant with proper table source format.
+* Field mappings are defined as multiple `field_mapping` blocks. The order of field mappings is preserved.
+* The `source_attributes` and `destination_attributes` are configuration blocks, not JSON-encoded strings.
 * Sync operations:
   * `upsert` - Insert new records and update existing ones
   * `append` - Only insert new records, never update
   * `mirror` - Replace all destination records with source data
-* Manual syncs (frequency="manual") must be triggered externally.
+* Manual syncs (frequency="never") must be triggered externally.
 * Source types determine which fields are required in `source_attributes.object`.
+  * For segment sources, use `type="segment"` with `id` (segment ID) and `dataset_id` (parent dataset ID)
+  * For cohort sources, use `type="cohort"` with `id` (cohort ID) and `dataset_id` (parent dataset ID)


### PR DESCRIPTION
## Fix Documentation Drift in Terraform Provider Resources

  ### Summary
  This PR fixes documentation drift across multiple resources where examples and field references didn't match the actual Terraform provider implementation. The main issues were outdated field names, incorrect syntax patterns, and removed features still being documented.

  ### Changes

  #### 1. `docs/resources/sync.md` - Major Updates

  **Fixed Schema Syntax Issues:**
  - ✅ Changed `name` → `label` throughout all examples
  - ✅ Fixed `source_attributes` from `jsonencode({...})` → proper block syntax:
    ```hcl
    source_attributes {
      connection_id = census_source.warehouse.id
      object {
        type = "table"
        table_name = "users"
      }
    }
  - ✅ Fixed destination_object = "..." → proper destination_attributes block:
  destination_attributes {
    connection_id = census_destination.salesforce.id
    object = "Contact"
  }
  - ✅ Fixed field_mapping = [...] array syntax → multiple field_mapping {} blocks:
  field_mapping {
    from = "email"
    to   = "Email"
    is_primary_identifier = true
  }

  field_mapping {
    from = "first_name"
    to   = "FirstName"
  }
  - ✅ Fixed alert = [...] array syntax → multiple alert {} blocks

  Removed Unsupported Features:
  - ❌ Removed type = "hash" from field mapping examples (not implemented in API)
  - ❌ Removed "hash" from valid field mapping types in documentation
  - Updated resource_sync.go, data_source_sync.go to remove "hash" from validation

  Added New Example:
  - ➕ Added "Sync to Google Sheets (Mirror with Auto-Mapping)" example demonstrating:
    - Mirror operation to Google Sheets
    - field_behavior = "sync_all_properties"
    - Google Sheets-specific object format with JSON

  Updated Documentation Sections:
  - Fixed segment source example to use proper format with type="segment", id, and dataset_id
  - Updated Argument Reference to reflect correct field types and names
  - Updated Notes section to clarify blocks vs arrays

  2. docs/resources/destination.md

  Fixed Field References:
  - ✅ Line 90: Changed credentials → connection_config in Notes section
  - ✅ Line 71-72: Updated Attribute Reference:
    - Removed: connection_status
    - Added: status and test_status (matching actual schema)

  3. docs/resources/source.md

  Fixed Field References:
  - ✅ Line 119: Changed credentials → connection_config in Notes section
  - ✅ Line 100-101: Updated Attribute Reference:
    - Removed: connection_status
    - Added: status and test_status (matching actual schema)

  4. docs/resources/dataset.md ✅

  - No changes needed - already aligned with implementation

  5. docs/resources/workspace.md ✅

  - No changes needed - already aligned with implementation

  Impact

  Before: Documentation had multiple drift issues:
  - Examples used incorrect syntax (jsonencode, array notation)
  - Wrong field names (name vs label, credentials vs connection_config)
  - Documented features that don't exist (hash type)
  - Missing required field examples (table_catalog, table_schema)

  After: All documentation examples:
  - ✅ Use correct Terraform HCL block syntax
  - ✅ Reference correct field names matching the schema
  - ✅ Include all required fields
  - ✅ Remove unsupported/unimplemented features
  - ✅ Follow consistent patterns across all examples

  Testing

  - All documentation examples validated against provider schema definitions
  - Code compiles successfully with "hash" type removed from validation