### PR TITLE
fix sync all diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.2.9] - 2025-01-02
 
 ### Fixed
+- **Field Mapping Drift with sync_all_properties**: Fixed unwanted Terraform plan diffs for field mappings when using `field_behavior = "sync_all_properties"`. Previously, Census-managed auto-generated mappings would show as drift on every plan, requiring users to add `lifecycle { ignore_changes = [field_mapping] }` as a workaround. Now the provider uses `CustomizeDiff` to intelligently merge user-configured mappings with Census-managed mappings, suppressing diffs for auto-generated fields while still showing changes for explicitly configured mappings.
+
 - **Alert Management**: Fixed alert lifecycle management to follow Terraform best practices. Previously, the provider would omit the `alert_attributes` field when no alerts were configured, causing the Census API to add default alerts on create and preserve existing alerts on update. The provider now always sends `alert_attributes` (as an empty array when no alerts are configured), ensuring:
   - Syncs created without alerts have no alerts (no default alerts added)
   - All alerts can be deleted from a sync by removing all `alert` blocks and applying
@@ -33,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Only retrying 429 errors (other errors like 5xx, network failures are not retried and fail immediately)
   - Providing debug and warning logs for retry attempts via Terraform's structured logging
   - Gracefully handling context cancellation and deadline exhaustion
+
 ### Removed
 - **BREAKING**: Removed `type = "hash"` as a valid field mapping type. This option was never implemented in the Census API and had no functional effect (it was treated identically to `type = "direct"`). Any configurations using `type = "hash"` should be changed to `type = "direct"` or simply omit the type field (direct is the default).
 

--- a/census/provider/resource_sync.go
+++ b/census/provider/resource_sync.go
@@ -674,9 +674,11 @@ func MergeFieldMappingsForSyncAll(stateMappings, configMappings []interface{}) [
 // by Census vs explicitly configured by user.
 // User-configured mappings have: is_primary_identifier, constant, liquid_template, or non-default operation.
 func IsCensusManagedMapping(m map[string]interface{}) bool {
-	// Primary identifiers are always user-configured
+	// Primary identifiers with direct type are always user-configured
 	if isPrimary, ok := m["is_primary_identifier"].(bool); ok && isPrimary {
-		return false
+		if mappingType, ok := m["type"].(string); ok && mappingType == "direct" {
+			return false
+		}
 	}
 
 	// Constant mappings are user-configured (no source field)

--- a/census/provider/resource_sync.go
+++ b/census/provider/resource_sync.go
@@ -676,7 +676,12 @@ func MergeFieldMappingsForSyncAll(stateMappings, configMappings []interface{}) [
 func IsCensusManagedMapping(m map[string]interface{}) bool {
 	// Primary identifiers with direct type are always user-configured
 	if isPrimary, ok := m["is_primary_identifier"].(bool); ok && isPrimary {
-		if mappingType, ok := m["type"].(string); ok && mappingType == "direct" {
+		// Type defaults to "direct" if not specified
+		mappingType := "direct"
+		if typeVal, ok := m["type"].(string); ok && typeVal != "" {
+			mappingType = typeVal
+		}
+		if mappingType == "direct" {
 			return false
 		}
 	}

--- a/census/provider/resource_sync.go
+++ b/census/provider/resource_sync.go
@@ -131,6 +131,7 @@ func syncSchemaMap(alertCollectionType schema.ValueType) map[string]*schema.Sche
 		"field_mapping": {
 			Type:        schema.TypeList,
 			Optional:    true,
+			Computed:    true,
 			Description: "Field mappings between source and destination.",
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
@@ -550,6 +551,8 @@ func ResourceSync() *schema.Resource {
 			},
 		},
 
+		CustomizeDiff: customizeSyncFieldMappingDiff,
+
 		Schema: syncSchemaMap(schema.TypeList),
 	}
 }
@@ -588,6 +591,118 @@ func suppressEquivalentJSON(k, old, new string, d *schema.ResourceData) bool {
 	}
 
 	return reflect.DeepEqual(oldJSON, newJSON)
+}
+
+// customizeSyncFieldMappingDiff suppresses field_mapping diffs for Census-managed
+// mappings when field_behavior = "sync_all_properties", while still showing diffs
+// for user-configured mappings.
+func customizeSyncFieldMappingDiff(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+	// Only apply on updates (not creates)
+	if d.Id() == "" {
+		return nil
+	}
+
+	// Only apply when using sync_all_properties mode
+	fieldBehavior := d.Get("field_behavior").(string)
+	if fieldBehavior != "sync_all_properties" {
+		return nil
+	}
+
+	oldRaw, newRaw := d.GetChange("field_mapping")
+	oldMappings, _ := oldRaw.([]interface{})
+	newMappings, _ := newRaw.([]interface{})
+
+	mergedMappings := MergeFieldMappingsForSyncAll(oldMappings, newMappings)
+
+	// Set merged value to suppress diff for Census-managed mappings
+	return d.SetNew("field_mapping", mergedMappings)
+}
+
+// MergeFieldMappingsForSyncAll merges user-configured mappings (from config) with
+// Census-managed mappings (from state) for sync_all_properties mode.
+// It preserves state order, uses user config values where specified, and appends
+// any new user mappings at the end.
+func MergeFieldMappingsForSyncAll(stateMappings, configMappings []interface{}) []interface{} {
+	// Build map of user-configured mappings by "to" field (from config)
+	userConfiguredByTo := make(map[string]interface{})
+	for _, mapping := range configMappings {
+		if m, ok := mapping.(map[string]interface{}); ok {
+			if to, ok := m["to"].(string); ok {
+				userConfiguredByTo[to] = mapping
+			}
+		}
+	}
+
+	// Build merged list preserving state order, but using user config values where specified
+	mergedMappings := make([]interface{}, 0, len(stateMappings))
+
+	// Track which user-configured mappings we've added
+	addedUserMappings := make(map[string]bool)
+
+	// First pass: iterate through state mappings in order
+	for _, stateMapping := range stateMappings {
+		if m, ok := stateMapping.(map[string]interface{}); ok {
+			to, _ := m["to"].(string)
+			if userMapping, exists := userConfiguredByTo[to]; exists {
+				// User configured this mapping - use their version
+				mergedMappings = append(mergedMappings, userMapping)
+				addedUserMappings[to] = true
+			} else if IsCensusManagedMapping(m) {
+				// Census-managed (trivial) mapping - preserve from state
+				mergedMappings = append(mergedMappings, stateMapping)
+			}
+			// If not in config AND not Census-managed, it's a user mapping that was removed - drop it
+		}
+	}
+
+	// Second pass: add any new user-configured mappings not in state
+	for _, mapping := range configMappings {
+		if m, ok := mapping.(map[string]interface{}); ok {
+			if to, ok := m["to"].(string); ok {
+				if !addedUserMappings[to] {
+					// New mapping from user, add it
+					mergedMappings = append(mergedMappings, mapping)
+				}
+			}
+		}
+	}
+
+	return mergedMappings
+}
+
+// IsCensusManagedMapping returns true if the mapping appears to be auto-generated
+// by Census (trivial mapping) vs explicitly configured by user.
+// Trivial mappings have from=to, operation=set, and no customizations.
+func IsCensusManagedMapping(m map[string]interface{}) bool {
+	// Primary identifiers are always user-configured
+	if isPrimary, ok := m["is_primary_identifier"].(bool); ok && isPrimary {
+		return false
+	}
+
+	// Constant mappings are user-configured (no source field)
+	if constant, ok := m["constant"].(string); ok && constant != "" {
+		return false
+	}
+
+	// Liquid template mappings are user-configured
+	if liquid, ok := m["liquid_template"].(string); ok && liquid != "" {
+		return false
+	}
+
+	// Non-default operations are user-configured
+	if op, ok := m["operation"].(string); ok && op != "" && op != "set" {
+		return false
+	}
+
+	// If from != to, it's a user-configured rename
+	from, _ := m["from"].(string)
+	to, _ := m["to"].(string)
+	if from != "" && to != "" && from != to {
+		return false
+	}
+
+	// Trivial mapping: from=X, to=X, operation=set - Census auto-generated
+	return true
 }
 
 func resourceSyncCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/census/provider/resource_sync.go
+++ b/census/provider/resource_sync.go
@@ -671,8 +671,8 @@ func MergeFieldMappingsForSyncAll(stateMappings, configMappings []interface{}) [
 }
 
 // IsCensusManagedMapping returns true if the mapping appears to be auto-generated
-// by Census (trivial mapping) vs explicitly configured by user.
-// Trivial mappings have from=to, operation=set, and no customizations.
+// by Census vs explicitly configured by user.
+// User-configured mappings have: is_primary_identifier, constant, liquid_template, or non-default operation.
 func IsCensusManagedMapping(m map[string]interface{}) bool {
 	// Primary identifiers are always user-configured
 	if isPrimary, ok := m["is_primary_identifier"].(bool); ok && isPrimary {
@@ -694,14 +694,11 @@ func IsCensusManagedMapping(m map[string]interface{}) bool {
 		return false
 	}
 
-	// If from != to, it's a user-configured rename
-	from, _ := m["from"].(string)
-	to, _ := m["to"].(string)
-	if from != "" && to != "" && from != to {
-		return false
-	}
+	// Note: We do NOT check from != to because Census can auto-generate mappings
+	// with different from/to values when field_normalization is enabled
+	// (e.g., "beepBoop" -> "beep_boop" with snake_case normalization)
 
-	// Trivial mapping: from=X, to=X, operation=set - Census auto-generated
+	// If none of the above, it's a Census-managed mapping
 	return true
 }
 

--- a/census/tests/provider/unit/resource_sync_test.go
+++ b/census/tests/provider/unit/resource_sync_test.go
@@ -1413,3 +1413,121 @@ func TestConvertMappingAttributesToFieldMappings_RoundTrip(t *testing.T) {
 func boolPtr(b bool) *bool {
 	return &b
 }
+
+// ============================================================================
+// MergeFieldMappingsForSyncAll Tests (CustomizeDiff helper)
+// ============================================================================
+
+func TestMergeFieldMappingsForSyncAll_PreservesStateOrder(t *testing.T) {
+	// State has: id, email, first_name (Census auto-generated)
+	// Config has: id (user-configured)
+	// Result should preserve state order, no changes
+	stateMappings := []interface{}{
+		map[string]interface{}{"from": "id", "to": "id", "is_primary_identifier": true},
+		map[string]interface{}{"from": "email", "to": "email"},
+		map[string]interface{}{"from": "first_name", "to": "first_name"},
+	}
+	configMappings := []interface{}{
+		map[string]interface{}{"from": "id", "to": "id", "is_primary_identifier": true},
+	}
+
+	result := provider.MergeFieldMappingsForSyncAll(stateMappings, configMappings)
+
+	if len(result) != 3 {
+		t.Errorf("Expected 3 mappings, got %d", len(result))
+	}
+
+	// Verify order is preserved
+	expectedTos := []string{"id", "email", "first_name"}
+	for i, mapping := range result {
+		m := mapping.(map[string]interface{})
+		if m["to"] != expectedTos[i] {
+			t.Errorf("Position %d: expected 'to'=%s, got %s", i, expectedTos[i], m["to"])
+		}
+	}
+}
+
+func TestMergeFieldMappingsForSyncAll_UserAddsNewMapping(t *testing.T) {
+	// State has: id, email (from Census)
+	// Config has: id, beep_beep (user adds new constant mapping)
+	// Result should have: id, email, beep_beep (new mapping at end)
+	stateMappings := []interface{}{
+		map[string]interface{}{"from": "id", "to": "id", "is_primary_identifier": true},
+		map[string]interface{}{"from": "email", "to": "email"},
+	}
+	configMappings := []interface{}{
+		map[string]interface{}{"from": "id", "to": "id", "is_primary_identifier": true},
+		map[string]interface{}{"type": "constant", "constant": "coolbeans", "to": "beep_beep"},
+	}
+
+	result := provider.MergeFieldMappingsForSyncAll(stateMappings, configMappings)
+
+	if len(result) != 3 {
+		t.Errorf("Expected 3 mappings, got %d", len(result))
+	}
+
+	// New mapping should be at end
+	lastMapping := result[2].(map[string]interface{})
+	if lastMapping["to"] != "beep_beep" {
+		t.Errorf("Expected new mapping 'beep_beep' at end, got %s", lastMapping["to"])
+	}
+	if lastMapping["constant"] != "coolbeans" {
+		t.Errorf("Expected constant 'coolbeans', got %v", lastMapping["constant"])
+	}
+}
+
+func TestMergeFieldMappingsForSyncAll_UserModifiesMapping(t *testing.T) {
+	// State has: id (with from=id)
+	// Config has: id (with from=user_id - user changed it)
+	// Result should use user's version
+	stateMappings := []interface{}{
+		map[string]interface{}{"from": "id", "to": "id", "is_primary_identifier": true},
+	}
+	configMappings := []interface{}{
+		map[string]interface{}{"from": "user_id", "to": "id", "is_primary_identifier": true},
+	}
+
+	result := provider.MergeFieldMappingsForSyncAll(stateMappings, configMappings)
+
+	if len(result) != 1 {
+		t.Errorf("Expected 1 mapping, got %d", len(result))
+	}
+
+	mapping := result[0].(map[string]interface{})
+	if mapping["from"] != "user_id" {
+		t.Errorf("Expected user's 'from'=user_id, got %s", mapping["from"])
+	}
+}
+
+func TestMergeFieldMappingsForSyncAll_EmptyState(t *testing.T) {
+	// State is empty (new resource)
+	// Config has mappings
+	// Result should just be config mappings
+	stateMappings := []interface{}{}
+	configMappings := []interface{}{
+		map[string]interface{}{"from": "id", "to": "id", "is_primary_identifier": true},
+	}
+
+	result := provider.MergeFieldMappingsForSyncAll(stateMappings, configMappings)
+
+	if len(result) != 1 {
+		t.Errorf("Expected 1 mapping, got %d", len(result))
+	}
+}
+
+func TestMergeFieldMappingsForSyncAll_EmptyConfig(t *testing.T) {
+	// State has Census mappings
+	// Config is empty (user doesn't specify any)
+	// Result should preserve all state mappings
+	stateMappings := []interface{}{
+		map[string]interface{}{"from": "id", "to": "id"},
+		map[string]interface{}{"from": "email", "to": "email"},
+	}
+	configMappings := []interface{}{}
+
+	result := provider.MergeFieldMappingsForSyncAll(stateMappings, configMappings)
+
+	if len(result) != 2 {
+		t.Errorf("Expected 2 mappings, got %d", len(result))
+	}
+}

--- a/census/tests/provider/unit/resource_sync_test.go
+++ b/census/tests/provider/unit/resource_sync_test.go
@@ -1531,3 +1531,105 @@ func TestMergeFieldMappingsForSyncAll_EmptyConfig(t *testing.T) {
 		t.Errorf("Expected 2 mappings, got %d", len(result))
 	}
 }
+
+func TestMergeFieldMappingsForSyncAll_RemovesUserConfiguredMappings(t *testing.T) {
+	// State has: trivial mapping (Census) + constant mapping (user)
+	// Config removes the constant mapping
+	// Result should drop the constant mapping but keep the trivial one
+	stateMappings := []interface{}{
+		map[string]interface{}{"from": "id", "to": "id", "is_primary_identifier": true},
+		map[string]interface{}{"from": "email", "to": "email"},             // Census-managed (trivial)
+		map[string]interface{}{"constant": "coolbeans", "to": "beep_beep"}, // User-configured
+	}
+	// User removes the constant mapping and also removes the primary ID (keeping only trivial in config)
+	configMappings := []interface{}{
+		map[string]interface{}{"from": "id", "to": "id", "is_primary_identifier": true},
+	}
+
+	result := provider.MergeFieldMappingsForSyncAll(stateMappings, configMappings)
+
+	// Should have: primary ID (from config) + email (Census-managed, preserved)
+	// Should NOT have: constant mapping (user-configured, removed from config)
+	if len(result) != 2 {
+		t.Errorf("Expected 2 mappings, got %d", len(result))
+	}
+
+	// Verify constant mapping was dropped
+	for _, m := range result {
+		mapping := m.(map[string]interface{})
+		if to, _ := mapping["to"].(string); to == "beep_beep" {
+			t.Error("Expected constant mapping to beep_beep to be removed, but it was preserved")
+		}
+	}
+}
+
+// ============================================================================
+// IsCensusManagedMapping Tests
+// ============================================================================
+
+func TestIsCensusManagedMapping_TrivialMappings(t *testing.T) {
+	// These should all return true (Census-managed)
+	trivialMappings := []map[string]interface{}{
+		{"from": "email", "to": "email"},
+		{"from": "name", "to": "name", "operation": "set"},
+		{"from": "id", "to": "id", "operation": ""},
+	}
+
+	for i, m := range trivialMappings {
+		if !provider.IsCensusManagedMapping(m) {
+			t.Errorf("Case %d: Expected trivial mapping to be Census-managed: %v", i, m)
+		}
+	}
+}
+
+func TestIsCensusManagedMapping_PrimaryIdentifier(t *testing.T) {
+	m := map[string]interface{}{
+		"from":                  "id",
+		"to":                    "id",
+		"is_primary_identifier": true,
+	}
+	if provider.IsCensusManagedMapping(m) {
+		t.Error("Primary identifier mapping should NOT be Census-managed")
+	}
+}
+
+func TestIsCensusManagedMapping_ConstantMapping(t *testing.T) {
+	m := map[string]interface{}{
+		"constant": "some_value",
+		"to":       "destination_field",
+	}
+	if provider.IsCensusManagedMapping(m) {
+		t.Error("Constant mapping should NOT be Census-managed")
+	}
+}
+
+func TestIsCensusManagedMapping_LiquidTemplate(t *testing.T) {
+	m := map[string]interface{}{
+		"liquid_template": "{{ row.first_name }} {{ row.last_name }}",
+		"to":              "full_name",
+	}
+	if provider.IsCensusManagedMapping(m) {
+		t.Error("Liquid template mapping should NOT be Census-managed")
+	}
+}
+
+func TestIsCensusManagedMapping_NonDefaultOperation(t *testing.T) {
+	m := map[string]interface{}{
+		"from":      "email",
+		"to":        "email_hash",
+		"operation": "hash",
+	}
+	if provider.IsCensusManagedMapping(m) {
+		t.Error("Non-default operation mapping should NOT be Census-managed")
+	}
+}
+
+func TestIsCensusManagedMapping_Rename(t *testing.T) {
+	m := map[string]interface{}{
+		"from": "source_field",
+		"to":   "destination_field",
+	}
+	if provider.IsCensusManagedMapping(m) {
+		t.Error("Rename mapping (from != to) should NOT be Census-managed")
+	}
+}

--- a/census/tests/provider/unit/resource_sync_test.go
+++ b/census/tests/provider/unit/resource_sync_test.go
@@ -1624,12 +1624,14 @@ func TestIsCensusManagedMapping_NonDefaultOperation(t *testing.T) {
 	}
 }
 
-func TestIsCensusManagedMapping_Rename(t *testing.T) {
+func TestIsCensusManagedMapping_RenameIsCensusManaged(t *testing.T) {
+	// Rename mappings (from != to) ARE Census-managed because field_normalization
+	// can auto-generate them (e.g., "beepBoop" -> "beep_boop" with snake_case)
 	m := map[string]interface{}{
 		"from": "source_field",
 		"to":   "destination_field",
 	}
-	if provider.IsCensusManagedMapping(m) {
-		t.Error("Rename mapping (from != to) should NOT be Census-managed")
+	if !provider.IsCensusManagedMapping(m) {
+		t.Error("Rename mapping (from != to) SHOULD be Census-managed (field normalization)")
 	}
 }

--- a/census/tests/provider/unit/resource_sync_test.go
+++ b/census/tests/provider/unit/resource_sync_test.go
@@ -1593,6 +1593,18 @@ func TestIsCensusManagedMapping_PrimaryIdentifier(t *testing.T) {
 	}
 }
 
+func TestIsCensusManagedMapping_PrimaryIdentifierDirect(t *testing.T) {
+	m := map[string]interface{}{
+		"from":                  "id",
+		"to":                    "id",
+		"is_primary_identifier": true,
+		"type":                  "direct",
+	}
+	if provider.IsCensusManagedMapping(m) {
+		t.Error("Primary identifier with direct type should NOT be Census-managed")
+	}
+}
+
 func TestIsCensusManagedMapping_ConstantMapping(t *testing.T) {
 	m := map[string]interface{}{
 		"constant": "some_value",


### PR DESCRIPTION
## Description of the change

Fixed unwanted Terraform plan diffs for field mappings when using `field_behavior = "sync_all_properties"
