### PR TITLE
Support configuring no alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.2.9] - 2025-01-02
 
 ### Fixed
-- **Alert Deletion**: Fixed bug preventing deletion of all alerts from a sync resource. Previously, when removing all alert blocks from a sync configuration, the provider would not send the `alert_attributes` field to the Census API, causing the API to preserve existing alerts. The provider now correctly sends `"alert_attributes": []` to delete all alerts when none are configured.
+- **Alert Management**: Fixed alert lifecycle management to follow Terraform best practices. Previously, the provider would omit the `alert_attributes` field when no alerts were configured, causing the Census API to add default alerts on create and preserve existing alerts on update. The provider now always sends `alert_attributes` (as an empty array when no alerts are configured), ensuring:
+  - Syncs created without alerts have no alerts (no default alerts added)
+  - All alerts can be deleted from a sync by removing all `alert` blocks and applying
+  - Terraform state matches user configuration with no unexpected drift
 
 ## [0.2.8] - 2025-12-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **[PLANNED]** Migrate `field_mapping` from TypeList to TypeSet for true order independence. This will cause a one-time diff showing all mappings as "replaced" during upgrade, but eliminates all future order-related drift. The migration is automatic and safe - mappings are keyed by destination field ("to") which is unique per sync. Users will see a large but harmless diff on first upgrade.
 
+## [0.2.9] - 2025-01-02
+
+### Fixed
+- **Alert Deletion**: Fixed bug preventing deletion of all alerts from a sync resource. Previously, when removing all alert blocks from a sync configuration, the provider would not send the `alert_attributes` field to the Census API, causing the API to preserve existing alerts. The provider now correctly sends `"alert_attributes": []` to delete all alerts when none are configured.
+
 ## [0.2.8] - 2025-12-30
 
 ### Fixed

--- a/census/client/sync.go
+++ b/census/client/sync.go
@@ -181,8 +181,9 @@ type CreateSyncRequest struct {
 	Mappings              []MappingAttributes    `json:"mappings"`               // Required: Field mappings
 
 	// Optional fields
-	Label           string           `json:"label,omitempty"`
-	AlertAttributes []AlertAttribute `json:"alert_attributes,omitempty"`
+	Label string `json:"label,omitempty"`
+	// Note: No omitempty tag - we need to send empty array to prevent default alerts
+	AlertAttributes []AlertAttribute `json:"alert_attributes"`
 
 	// Schedule fields - Census Management API expects these as flat fields, not nested object
 	ScheduleFrequency string `json:"schedule_frequency,omitempty"`

--- a/census/client/sync.go
+++ b/census/client/sync.go
@@ -259,7 +259,8 @@ type UpdateSyncRequest struct {
 	MirrorStrategy string `json:"mirror_strategy,omitempty"` // sync_updates_and_deletes, sync_updates_and_nulls, upload_and_swap
 
 	// Alert configuration
-	AlertAttributes []AlertAttribute `json:"alert_attributes,omitempty"`
+	// Note: No omitempty tag - we need to send empty array to delete all alerts
+	AlertAttributes []AlertAttribute `json:"alert_attributes"`
 }
 
 // SyncResponse represents a single sync response

--- a/census/provider/resource_sync.go
+++ b/census/provider/resource_sync.go
@@ -1240,11 +1240,14 @@ func FlattenFieldMappings(mappings []client.FieldMapping) []interface{} {
 }
 
 func ExpandAlerts(alerts []interface{}) []client.AlertAttribute {
-	if len(alerts) == 0 {
-		return nil
-	}
-
+	// Return empty slice instead of nil to allow deleting all alerts
+	// When nil is used, the omitempty tag causes the field to be omitted entirely
+	// from the JSON, which the API interprets as "don't change"
 	result := make([]client.AlertAttribute, 0, len(alerts))
+
+	if len(alerts) == 0 {
+		return result
+	}
 	for i, alert := range alerts {
 		m, ok := alert.(map[string]interface{})
 		if !ok {

--- a/census/tests/provider/unit/resource_sync_test.go
+++ b/census/tests/provider/unit/resource_sync_test.go
@@ -352,8 +352,11 @@ func TestExpandAlerts_Basic(t *testing.T) {
 
 func TestExpandAlerts_Empty(t *testing.T) {
 	result := provider.ExpandAlerts([]interface{}{})
-	if result != nil {
-		t.Errorf("ExpandAlerts(empty) should return nil, got %d items", len(result))
+	if result == nil {
+		t.Errorf("ExpandAlerts(empty) should return empty slice, got nil")
+	}
+	if len(result) != 0 {
+		t.Errorf("ExpandAlerts(empty) should return empty slice with 0 items, got %d items", len(result))
 	}
 }
 

--- a/docs/resources/sync.md
+++ b/docs/resources/sync.md
@@ -824,7 +824,7 @@ resource "census_sync" "preserve_example" {
   * `"sync_updates_and_deletes"` - Incrementally syncs changes by inserting new records, updating modified records, and deleting records that no longer exist in the source. This is the most common and efficient strategy for keeping destinations in sync (default).
   * `"sync_updates_and_nulls"` - Updates existing records and sets fields to null when the source contains null values, without performing deletes.
   * `"upload_and_swap"` - Replaces the entire destination table with the current source snapshot. Useful for destinations that don't support incremental updates or when you need a complete refresh.
-* `alert` - (Optional) Alert configurations for monitoring sync health. Define multiple `alert` blocks to configure multiple alerts. Each alert block includes:
+* `alert` - (Optional) Alert configurations for monitoring sync health. Define multiple `alert` blocks to configure multiple alerts. If no `alert` blocks are specified, the sync will be created with no alerts. Each alert block includes:
   * `type` - (Required) Type of alert. Valid values:
     * `"FailureAlertConfiguration"` - Alert when sync fails completely
     * `"InvalidRecordPercentAlertConfiguration"` - Alert when invalid/rejected records exceed threshold


### PR DESCRIPTION
# Fix: Alert Lifecycle Management to Follow Terraform Best Practices

## Problem

The provider didn't properly manage the alert lifecycle:
- **On Create**: When no alerts were configured, Census API added default alerts, causing unexpected drift
- **On Update**: Removing all alerts didn't delete them from Census, making full lifecycle management impossible

Both issues stemmed from omitting the `alert_attributes` field from API requests when no alerts were configured.

## Solution

Always send `alert_attributes` to the API, even when empty:

1. **`resource_sync.go`**: Changed `ExpandAlerts()` to return `[]` instead of `nil` for empty alerts
2. **`sync.go`**: Removed `omitempty` tag from `AlertAttributes` in both `CreateSyncRequest` and 
`UpdateSyncRequest`

Now the provider sends `"alert_attributes": []` when no alerts are configured.

## Result

- ✅ Syncs created without alerts have no alerts (no defaults added)
- ✅ All alerts can be deleted by removing alert blocks
- ✅ Terraform state matches user configuration with no drift
- ✅ Full alert lifecycle management: create, update, delete, and delete all

## Testing

- All unit tests pass (updated `TestExpandAlerts_Empty`)
- Manually verified: create without alerts, delete all alerts, partial deletion, updates

## Impact

**Backwards Compatible**: Yes, improves behavior without breaking changes
