### PR TITLE
Order mappings from Census API by position to match resource [RD-1144781]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,18 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased - v0.3.0]
-
-### Changed
-- **[PLANNED]** Migrate `field_mapping` from TypeList to TypeSet for true order independence. This will cause a one-time diff showing all mappings as "replaced" during upgrade, but eliminates all future order-related drift. The migration is automatic and safe - mappings are keyed by destination field ("to") which is unique per sync. Users will see a large but harmless diff on first upgrade.
-
-## [0.2.9] - 2025-01-02
+## [0.2.9] - Unreleased
 
 ### Fixed
 - **Alert Management**: Fixed alert lifecycle management to follow Terraform best practices. Previously, the provider would omit the `alert_attributes` field when no alerts were configured, causing the Census API to add default alerts on create and preserve existing alerts on update. The provider now always sends `alert_attributes` (as an empty array when no alerts are configured), ensuring:
   - Syncs created without alerts have no alerts (no default alerts added)
   - All alerts can be deleted from a sync by removing all `alert` blocks and applying
   - Terraform state matches user configuration with no unexpected drift
+- **Field Mapping Order Drift**: Fixed spurious diffs in `field_mapping` blocks caused by non-deterministic ordering from the Census API. The Census API now exposes a `position` field that represents the canonical order of mappings (set based on the order they appear in API requests). The provider sorts mappings by position before comparing to Terraform state, ensuring:
+  - Mappings are always returned in their canonical order
+  - Works correctly regardless of `field_order` setting ("mapping_order" or "alphabetical_column_name")
+  - Real changes to mapping order are properly detected
+  - No spurious diffs when nothing has changed
+  - Requires Census API v0.2.9+ for position field support
 
 ## [0.2.8] - 2025-12-30
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 BINARY_NAME=terraform-provider-census
-VERSION=0.2.8
+VERSION=0.2.9
 BUILD_DIR=bin
 LDFLAGS=-ldflags "-X main.version=${VERSION}"
 

--- a/census/client/sync.go
+++ b/census/client/sync.go
@@ -86,6 +86,7 @@ type AlertAttribute struct {
 type FieldMapping struct {
 	From                string      `json:"from"`
 	To                  string      `json:"to"`
+	Position            int         `json:"position"`                        // Position of mapping in the sync (0-indexed, set by Census API)
 	Type                string      `json:"operation,omitempty"`             // direct, hash, constant, sync_metadata, segment_membership, liquid_template - JSON is still "operation" for API compatibility
 	Constant            interface{} `json:"constant,omitempty"`              // For constant mappings
 	SyncMetadataKey     string      `json:"sync_metadata_key,omitempty"`     // For sync_metadata mappings (e.g., "sync_run_id")

--- a/census/client/sync.go
+++ b/census/client/sync.go
@@ -107,6 +107,7 @@ type FieldMapping struct {
 type MappingAttributes struct {
 	From                MappingFrom `json:"from"`
 	To                  string      `json:"to"`
+	Position            int         `json:"position"` // Position of mapping in the sync (0-indexed, set by Census API)
 	IsPrimaryIdentifier bool        `json:"is_primary_identifier"`
 	LookupObject        string      `json:"lookup_object,omitempty"`
 	LookupField         string      `json:"lookup_field,omitempty"`

--- a/census/provider/resource_sync.go
+++ b/census/provider/resource_sync.go
@@ -859,6 +859,14 @@ To fix this, add the missing workspace_id to terraform state:
 		fieldMappings = []client.FieldMapping{} // Empty slice as fallback
 	}
 
+	// Reorder API mappings to match state order by "to" field
+	// This prevents spurious diffs when the Census API returns mappings in a different order
+	stateMappings := d.Get("field_mapping").([]interface{})
+	if len(stateMappings) > 0 && len(fieldMappings) > 0 {
+		fmt.Printf("[DEBUG] Reordering field mappings to match state order\n")
+		fieldMappings = MatchFieldMappingsByTo(stateMappings, fieldMappings)
+	}
+
 	fmt.Printf("[DEBUG] Setting field_mapping\n")
 	if err := d.Set("field_mapping", FlattenFieldMappings(fieldMappings)); err != nil {
 		fmt.Printf("[DEBUG] Failed to set field_mapping: %v\n", err)
@@ -1236,6 +1244,58 @@ func FlattenFieldMappings(mappings []client.FieldMapping) []interface{} {
 
 		result[i] = mappingMap
 	}
+	return result
+}
+
+// MatchFieldMappingsByTo reorders API field mappings to match the order in Terraform state
+// based on the "to" field, which is unique. This prevents spurious diffs when the Census API
+// returns field mappings in a different order than they appear in the config.
+func MatchFieldMappingsByTo(stateMappings []interface{}, apiMappings []client.FieldMapping) []client.FieldMapping {
+	fmt.Printf("[DEBUG] matchFieldMappingsByTo: state count=%d, api count=%d\n", len(stateMappings), len(apiMappings))
+
+	// Build map: "to" value -> API mapping
+	apiMap := make(map[string]client.FieldMapping)
+	for _, m := range apiMappings {
+		apiMap[m.To] = m
+		fmt.Printf("[DEBUG] matchFieldMappingsByTo: API mapping to=%s\n", m.To)
+	}
+
+	// Reconstruct in state order
+	result := make([]client.FieldMapping, 0, len(apiMappings))
+	seen := make(map[string]bool)
+
+	// First, add mappings in state order
+	for _, sm := range stateMappings {
+		stateMapping, ok := sm.(map[string]interface{})
+		if !ok {
+			fmt.Printf("[DEBUG] matchFieldMappingsByTo: skipping non-map state mapping: %T\n", sm)
+			continue
+		}
+
+		toField, ok := stateMapping["to"].(string)
+		if !ok {
+			fmt.Printf("[DEBUG] matchFieldMappingsByTo: skipping state mapping with non-string 'to': %T\n", stateMapping["to"])
+			continue
+		}
+
+		if apiMapping, exists := apiMap[toField]; exists {
+			fmt.Printf("[DEBUG] matchFieldMappingsByTo: matched state to=%s\n", toField)
+			result = append(result, apiMapping)
+			seen[toField] = true
+		} else {
+			fmt.Printf("[DEBUG] matchFieldMappingsByTo: state mapping to=%s not found in API response (removed)\n", toField)
+		}
+	}
+
+	// Then append any new mappings from API that weren't in state
+	for _, m := range apiMappings {
+		if !seen[m.To] {
+			fmt.Printf("[DEBUG] matchFieldMappingsByTo: appending new API mapping to=%s\n", m.To)
+			result = append(result, m)
+		}
+	}
+
+	fmt.Printf("[DEBUG] matchFieldMappingsByTo: result count=%d\n", len(result))
 	return result
 }
 

--- a/census/provider/resource_sync.go
+++ b/census/provider/resource_sync.go
@@ -1996,6 +1996,7 @@ func ConvertMappingAttributesToFieldMappings(mappings []client.MappingAttributes
 		result[i] = client.FieldMapping{
 			From:                from,
 			To:                  ma.To,
+			Position:            ma.Position,
 			Type:                mappingType,
 			Constant:            constant,
 			SyncMetadataKey:     syncMetadataKey,

--- a/census/provider/resource_sync.go
+++ b/census/provider/resource_sync.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -859,12 +860,14 @@ To fix this, add the missing workspace_id to terraform state:
 		fieldMappings = []client.FieldMapping{} // Empty slice as fallback
 	}
 
-	// Reorder API mappings to match state order by "to" field
+	// Sort API mappings by position (Census's canonical order)
+	// Position is always set by Census API regardless of field_order setting
 	// This prevents spurious diffs when the Census API returns mappings in a different order
-	stateMappings := d.Get("field_mapping").([]interface{})
-	if len(stateMappings) > 0 && len(fieldMappings) > 0 {
-		fmt.Printf("[DEBUG] Reordering field mappings to match state order\n")
-		fieldMappings = MatchFieldMappingsByTo(stateMappings, fieldMappings)
+	if len(fieldMappings) > 0 {
+		fmt.Printf("[DEBUG] Sorting field mappings by position\n")
+		sort.Slice(fieldMappings, func(i, j int) bool {
+			return fieldMappings[i].Position < fieldMappings[j].Position
+		})
 	}
 
 	fmt.Printf("[DEBUG] Setting field_mapping\n")
@@ -1244,58 +1247,6 @@ func FlattenFieldMappings(mappings []client.FieldMapping) []interface{} {
 
 		result[i] = mappingMap
 	}
-	return result
-}
-
-// MatchFieldMappingsByTo reorders API field mappings to match the order in Terraform state
-// based on the "to" field, which is unique. This prevents spurious diffs when the Census API
-// returns field mappings in a different order than they appear in the config.
-func MatchFieldMappingsByTo(stateMappings []interface{}, apiMappings []client.FieldMapping) []client.FieldMapping {
-	fmt.Printf("[DEBUG] matchFieldMappingsByTo: state count=%d, api count=%d\n", len(stateMappings), len(apiMappings))
-
-	// Build map: "to" value -> API mapping
-	apiMap := make(map[string]client.FieldMapping)
-	for _, m := range apiMappings {
-		apiMap[m.To] = m
-		fmt.Printf("[DEBUG] matchFieldMappingsByTo: API mapping to=%s\n", m.To)
-	}
-
-	// Reconstruct in state order
-	result := make([]client.FieldMapping, 0, len(apiMappings))
-	seen := make(map[string]bool)
-
-	// First, add mappings in state order
-	for _, sm := range stateMappings {
-		stateMapping, ok := sm.(map[string]interface{})
-		if !ok {
-			fmt.Printf("[DEBUG] matchFieldMappingsByTo: skipping non-map state mapping: %T\n", sm)
-			continue
-		}
-
-		toField, ok := stateMapping["to"].(string)
-		if !ok {
-			fmt.Printf("[DEBUG] matchFieldMappingsByTo: skipping state mapping with non-string 'to': %T\n", stateMapping["to"])
-			continue
-		}
-
-		if apiMapping, exists := apiMap[toField]; exists {
-			fmt.Printf("[DEBUG] matchFieldMappingsByTo: matched state to=%s\n", toField)
-			result = append(result, apiMapping)
-			seen[toField] = true
-		} else {
-			fmt.Printf("[DEBUG] matchFieldMappingsByTo: state mapping to=%s not found in API response (removed)\n", toField)
-		}
-	}
-
-	// Then append any new mappings from API that weren't in state
-	for _, m := range apiMappings {
-		if !seen[m.To] {
-			fmt.Printf("[DEBUG] matchFieldMappingsByTo: appending new API mapping to=%s\n", m.To)
-			result = append(result, m)
-		}
-	}
-
-	fmt.Printf("[DEBUG] matchFieldMappingsByTo: result count=%d\n", len(result))
 	return result
 }
 

--- a/census/tests/provider/unit/resource_sync_test.go
+++ b/census/tests/provider/unit/resource_sync_test.go
@@ -2,6 +2,7 @@ package unit_test
 
 import (
 	"reflect"
+	"sort"
 	"testing"
 
 	"github.com/sutrolabs/terraform-provider-census/census/client"
@@ -301,310 +302,146 @@ func TestFlattenFieldMappings_Empty(t *testing.T) {
 // ============================================================================
 // Field Mapping Ordering Tests
 // ============================================================================
-// These tests verify that field mappings are reordered to match Terraform state
-// order based on the "to" field, preventing spurious diffs when the Census API
-// returns mappings in a different order.
+// These tests verify that field mappings are sorted by position from the Census API,
+// preventing spurious diffs when the API returns mappings in non-deterministic order.
 
-func TestMatchFieldMappingsByTo_PreservesStateOrder(t *testing.T) {
-	// Simulate state with mappings in a specific order
-	stateMappings := []interface{}{
-		map[string]interface{}{
-			"from": "email",
-			"to":   "Email",
-			"type": "direct",
+func TestSortFieldMappingsByPosition_Basic(t *testing.T) {
+	// Simulate API response with mappings in wrong order
+	mappings := []client.FieldMapping{
+		{
+			From:     "last_name",
+			To:       "LastName",
+			Position: 2,
+			Type:     "direct",
 		},
-		map[string]interface{}{
-			"from": "first_name",
-			"to":   "FirstName",
-			"type": "direct",
+		{
+			From:     "email",
+			To:       "Email",
+			Position: 0,
+			Type:     "direct",
 		},
-		map[string]interface{}{
-			"from": "last_name",
-			"to":   "LastName",
-			"type": "direct",
+		{
+			From:     "first_name",
+			To:       "FirstName",
+			Position: 1,
+			Type:     "direct",
 		},
 	}
 
-	// Simulate API response in different order
-	apiMappings := []client.FieldMapping{
-		{
-			From: "last_name",
-			To:   "LastName",
-			Type: "direct",
-		},
-		{
-			From: "email",
-			To:   "Email",
-			Type: "direct",
-		},
-		{
-			From: "first_name",
-			To:   "FirstName",
-			Type: "direct",
-		},
-	}
+	// Sort by position
+	sort.Slice(mappings, func(i, j int) bool {
+		return mappings[i].Position < mappings[j].Position
+	})
 
-	result := provider.MatchFieldMappingsByTo(stateMappings, apiMappings)
-
-	// Verify result matches state order
-	if len(result) != 3 {
-		t.Errorf("Expected 3 mappings, got %d", len(result))
+	// Verify result is sorted by position
+	if len(mappings) != 3 {
+		t.Errorf("Expected 3 mappings, got %d", len(mappings))
 	}
 
 	expectedOrder := []string{"Email", "FirstName", "LastName"}
-	for i, mapping := range result {
+	expectedPositions := []int{0, 1, 2}
+	for i, mapping := range mappings {
 		if mapping.To != expectedOrder[i] {
-			t.Errorf("Result[%d].To = %s, want %s", i, mapping.To, expectedOrder[i])
+			t.Errorf("Position %d: got %s, want %s", i, mapping.To, expectedOrder[i])
+		}
+		if mapping.Position != expectedPositions[i] {
+			t.Errorf("Mapping %d: got position %d, want %d", i, mapping.Position, expectedPositions[i])
 		}
 	}
 }
 
-func TestMatchFieldMappingsByTo_HandlesNewMappings(t *testing.T) {
-	// State has 2 mappings
-	stateMappings := []interface{}{
-		map[string]interface{}{
-			"from": "email",
-			"to":   "Email",
-		},
-		map[string]interface{}{
-			"from": "first_name",
-			"to":   "FirstName",
-		},
+func TestSortFieldMappingsByPosition_AlreadyOrdered(t *testing.T) {
+	// Simulate API response already in correct order
+	mappings := []client.FieldMapping{
+		{To: "Email", Position: 0},
+		{To: "FirstName", Position: 1},
+		{To: "LastName", Position: 2},
 	}
 
-	// API returns 3 mappings (one new)
-	apiMappings := []client.FieldMapping{
-		{
-			From: "email",
-			To:   "Email",
-			Type: "direct",
-		},
-		{
-			From: "last_name",
-			To:   "LastName", // New mapping not in state
-			Type: "direct",
-		},
-		{
-			From: "first_name",
-			To:   "FirstName",
-			Type: "direct",
-		},
-	}
+	// Sort by position (should be stable)
+	sort.Slice(mappings, func(i, j int) bool {
+		return mappings[i].Position < mappings[j].Position
+	})
 
-	result := provider.MatchFieldMappingsByTo(stateMappings, apiMappings)
-
-	// Verify result has all 3 mappings
-	if len(result) != 3 {
-		t.Errorf("Expected 3 mappings, got %d", len(result))
-	}
-
-	// First 2 should match state order
-	if result[0].To != "Email" {
-		t.Errorf("Result[0].To = %s, want Email", result[0].To)
-	}
-	if result[1].To != "FirstName" {
-		t.Errorf("Result[1].To = %s, want FirstName", result[1].To)
-	}
-
-	// New mapping should be appended at the end
-	if result[2].To != "LastName" {
-		t.Errorf("Result[2].To = %s, want LastName (new mapping should be at end)", result[2].To)
-	}
-}
-
-func TestMatchFieldMappingsByTo_HandlesRemovedMappings(t *testing.T) {
-	// State has 3 mappings
-	stateMappings := []interface{}{
-		map[string]interface{}{
-			"from": "email",
-			"to":   "Email",
-		},
-		map[string]interface{}{
-			"from": "first_name",
-			"to":   "FirstName",
-		},
-		map[string]interface{}{
-			"from": "last_name",
-			"to":   "LastName",
-		},
-	}
-
-	// API returns only 2 mappings (one removed)
-	apiMappings := []client.FieldMapping{
-		{
-			From: "email",
-			To:   "Email",
-			Type: "direct",
-		},
-		{
-			From: "last_name",
-			To:   "LastName",
-			Type: "direct",
-		},
-	}
-
-	result := provider.MatchFieldMappingsByTo(stateMappings, apiMappings)
-
-	// Verify result has only 2 mappings
-	if len(result) != 2 {
-		t.Errorf("Expected 2 mappings, got %d", len(result))
-	}
-
-	// Should preserve state order for remaining mappings
-	if result[0].To != "Email" {
-		t.Errorf("Result[0].To = %s, want Email", result[0].To)
-	}
-	if result[1].To != "LastName" {
-		t.Errorf("Result[1].To = %s, want LastName", result[1].To)
-	}
-
-	// Verify FirstName was removed
-	for _, mapping := range result {
-		if mapping.To == "FirstName" {
-			t.Errorf("FirstName mapping should have been removed")
+	// Verify order is unchanged
+	expectedOrder := []string{"Email", "FirstName", "LastName"}
+	for i, mapping := range mappings {
+		if mapping.To != expectedOrder[i] {
+			t.Errorf("Position %d: got %s, want %s", i, mapping.To, expectedOrder[i])
 		}
 	}
 }
 
-func TestMatchFieldMappingsByTo_MixedMappingTypes(t *testing.T) {
-	// Test with various mapping types (direct, constant, liquid_template, etc.)
-	stateMappings := []interface{}{
-		map[string]interface{}{
-			"from":                  "email",
-			"to":                    "Email",
-			"type":                  "direct",
-			"is_primary_identifier": true,
-		},
-		map[string]interface{}{
-			"to":       "Source",
-			"type":     "constant",
-			"constant": "Website",
-		},
-		map[string]interface{}{
-			"to":              "SyncRunID",
-			"type":            "sync_metadata",
-			"sync_metadata_key": "sync_run_id",
-		},
-		map[string]interface{}{
-			"to":              "FullName",
-			"type":            "liquid_template",
-			"liquid_template": "{{ first_name }} {{ last_name }}",
-		},
-	}
-
-	// API returns in completely different order
-	apiMappings := []client.FieldMapping{
+func TestSortFieldMappingsByPosition_MixedMappingTypes(t *testing.T) {
+	// Test with various mapping types in wrong order
+	mappings := []client.FieldMapping{
 		{
 			To:             "FullName",
+			Position:       3,
 			Type:           "liquid_template",
 			LiquidTemplate: "{{ first_name }} {{ last_name }}",
 		},
 		{
 			From:                "email",
 			To:                  "Email",
+			Position:            0,
 			Type:                "direct",
 			IsPrimaryIdentifier: true,
 		},
 		{
 			To:              "SyncRunID",
+			Position:        2,
 			Type:            "sync_metadata",
 			SyncMetadataKey: "sync_run_id",
 		},
 		{
 			To:       "Source",
+			Position: 1,
 			Type:     "constant",
 			Constant: "Website",
 		},
 	}
 
-	result := provider.MatchFieldMappingsByTo(stateMappings, apiMappings)
+	// Sort by position
+	sort.Slice(mappings, func(i, j int) bool {
+		return mappings[i].Position < mappings[j].Position
+	})
 
-	// Verify result has all 4 mappings
-	if len(result) != 4 {
-		t.Errorf("Expected 4 mappings, got %d", len(result))
-	}
-
-	// Verify order matches state
+	// Verify order matches positions
 	expectedOrder := []string{"Email", "Source", "SyncRunID", "FullName"}
-	for i, mapping := range result {
+	for i, mapping := range mappings {
 		if mapping.To != expectedOrder[i] {
-			t.Errorf("Result[%d].To = %s, want %s", i, mapping.To, expectedOrder[i])
+			t.Errorf("Position %d: got %s, want %s", i, mapping.To, expectedOrder[i])
 		}
 	}
 
 	// Verify types are preserved
-	if result[0].Type != "direct" || !result[0].IsPrimaryIdentifier {
+	if mappings[0].Type != "direct" || !mappings[0].IsPrimaryIdentifier {
 		t.Errorf("Email mapping should be direct type with primary identifier")
 	}
-	if result[1].Type != "constant" {
+	if mappings[1].Type != "constant" {
 		t.Errorf("Source mapping should be constant type")
 	}
-	if result[2].Type != "sync_metadata" {
+	if mappings[2].Type != "sync_metadata" {
 		t.Errorf("SyncRunID mapping should be sync_metadata type")
 	}
-	if result[3].Type != "liquid_template" {
+	if mappings[3].Type != "liquid_template" {
 		t.Errorf("FullName mapping should be liquid_template type")
 	}
 }
 
-func TestMatchFieldMappingsByTo_EmptyState(t *testing.T) {
-	// State is empty (new resource)
-	stateMappings := []interface{}{}
+func TestSortFieldMappingsByPosition_EmptySlice(t *testing.T) {
+	// Empty slice
+	mappings := []client.FieldMapping{}
 
-	// API returns mappings
-	apiMappings := []client.FieldMapping{
-		{
-			From: "email",
-			To:   "Email",
-			Type: "direct",
-		},
-		{
-			From: "first_name",
-			To:   "FirstName",
-			Type: "direct",
-		},
-	}
+	// Sort should not panic
+	sort.Slice(mappings, func(i, j int) bool {
+		return mappings[i].Position < mappings[j].Position
+	})
 
-	result := provider.MatchFieldMappingsByTo(stateMappings, apiMappings)
-
-	// Should return all API mappings in their original order
-	if len(result) != 2 {
-		t.Errorf("Expected 2 mappings, got %d", len(result))
-	}
-	if !reflect.DeepEqual(result, apiMappings) {
-		t.Errorf("With empty state, should return API mappings unchanged")
-	}
-}
-
-func TestMatchFieldMappingsByTo_EmptyAPI(t *testing.T) {
-	// State has mappings
-	stateMappings := []interface{}{
-		map[string]interface{}{
-			"from": "email",
-			"to":   "Email",
-		},
-	}
-
-	// API returns no mappings
-	apiMappings := []client.FieldMapping{}
-
-	result := provider.MatchFieldMappingsByTo(stateMappings, apiMappings)
-
-	// Should return empty result
-	if len(result) != 0 {
-		t.Errorf("Expected 0 mappings, got %d", len(result))
-	}
-}
-
-func TestMatchFieldMappingsByTo_BothEmpty(t *testing.T) {
-	stateMappings := []interface{}{}
-	apiMappings := []client.FieldMapping{}
-
-	result := provider.MatchFieldMappingsByTo(stateMappings, apiMappings)
-
-	// Should return empty result
-	if len(result) != 0 {
-		t.Errorf("Expected 0 mappings, got %d", len(result))
+	// Should still be empty
+	if len(mappings) != 0 {
+		t.Errorf("Expected 0 mappings, got %d", len(mappings))
 	}
 }
 

--- a/census/tests/provider/unit/resource_sync_test.go
+++ b/census/tests/provider/unit/resource_sync_test.go
@@ -299,6 +299,316 @@ func TestFlattenFieldMappings_Empty(t *testing.T) {
 }
 
 // ============================================================================
+// Field Mapping Ordering Tests
+// ============================================================================
+// These tests verify that field mappings are reordered to match Terraform state
+// order based on the "to" field, preventing spurious diffs when the Census API
+// returns mappings in a different order.
+
+func TestMatchFieldMappingsByTo_PreservesStateOrder(t *testing.T) {
+	// Simulate state with mappings in a specific order
+	stateMappings := []interface{}{
+		map[string]interface{}{
+			"from": "email",
+			"to":   "Email",
+			"type": "direct",
+		},
+		map[string]interface{}{
+			"from": "first_name",
+			"to":   "FirstName",
+			"type": "direct",
+		},
+		map[string]interface{}{
+			"from": "last_name",
+			"to":   "LastName",
+			"type": "direct",
+		},
+	}
+
+	// Simulate API response in different order
+	apiMappings := []client.FieldMapping{
+		{
+			From: "last_name",
+			To:   "LastName",
+			Type: "direct",
+		},
+		{
+			From: "email",
+			To:   "Email",
+			Type: "direct",
+		},
+		{
+			From: "first_name",
+			To:   "FirstName",
+			Type: "direct",
+		},
+	}
+
+	result := provider.MatchFieldMappingsByTo(stateMappings, apiMappings)
+
+	// Verify result matches state order
+	if len(result) != 3 {
+		t.Errorf("Expected 3 mappings, got %d", len(result))
+	}
+
+	expectedOrder := []string{"Email", "FirstName", "LastName"}
+	for i, mapping := range result {
+		if mapping.To != expectedOrder[i] {
+			t.Errorf("Result[%d].To = %s, want %s", i, mapping.To, expectedOrder[i])
+		}
+	}
+}
+
+func TestMatchFieldMappingsByTo_HandlesNewMappings(t *testing.T) {
+	// State has 2 mappings
+	stateMappings := []interface{}{
+		map[string]interface{}{
+			"from": "email",
+			"to":   "Email",
+		},
+		map[string]interface{}{
+			"from": "first_name",
+			"to":   "FirstName",
+		},
+	}
+
+	// API returns 3 mappings (one new)
+	apiMappings := []client.FieldMapping{
+		{
+			From: "email",
+			To:   "Email",
+			Type: "direct",
+		},
+		{
+			From: "last_name",
+			To:   "LastName", // New mapping not in state
+			Type: "direct",
+		},
+		{
+			From: "first_name",
+			To:   "FirstName",
+			Type: "direct",
+		},
+	}
+
+	result := provider.MatchFieldMappingsByTo(stateMappings, apiMappings)
+
+	// Verify result has all 3 mappings
+	if len(result) != 3 {
+		t.Errorf("Expected 3 mappings, got %d", len(result))
+	}
+
+	// First 2 should match state order
+	if result[0].To != "Email" {
+		t.Errorf("Result[0].To = %s, want Email", result[0].To)
+	}
+	if result[1].To != "FirstName" {
+		t.Errorf("Result[1].To = %s, want FirstName", result[1].To)
+	}
+
+	// New mapping should be appended at the end
+	if result[2].To != "LastName" {
+		t.Errorf("Result[2].To = %s, want LastName (new mapping should be at end)", result[2].To)
+	}
+}
+
+func TestMatchFieldMappingsByTo_HandlesRemovedMappings(t *testing.T) {
+	// State has 3 mappings
+	stateMappings := []interface{}{
+		map[string]interface{}{
+			"from": "email",
+			"to":   "Email",
+		},
+		map[string]interface{}{
+			"from": "first_name",
+			"to":   "FirstName",
+		},
+		map[string]interface{}{
+			"from": "last_name",
+			"to":   "LastName",
+		},
+	}
+
+	// API returns only 2 mappings (one removed)
+	apiMappings := []client.FieldMapping{
+		{
+			From: "email",
+			To:   "Email",
+			Type: "direct",
+		},
+		{
+			From: "last_name",
+			To:   "LastName",
+			Type: "direct",
+		},
+	}
+
+	result := provider.MatchFieldMappingsByTo(stateMappings, apiMappings)
+
+	// Verify result has only 2 mappings
+	if len(result) != 2 {
+		t.Errorf("Expected 2 mappings, got %d", len(result))
+	}
+
+	// Should preserve state order for remaining mappings
+	if result[0].To != "Email" {
+		t.Errorf("Result[0].To = %s, want Email", result[0].To)
+	}
+	if result[1].To != "LastName" {
+		t.Errorf("Result[1].To = %s, want LastName", result[1].To)
+	}
+
+	// Verify FirstName was removed
+	for _, mapping := range result {
+		if mapping.To == "FirstName" {
+			t.Errorf("FirstName mapping should have been removed")
+		}
+	}
+}
+
+func TestMatchFieldMappingsByTo_MixedMappingTypes(t *testing.T) {
+	// Test with various mapping types (direct, constant, liquid_template, etc.)
+	stateMappings := []interface{}{
+		map[string]interface{}{
+			"from":                  "email",
+			"to":                    "Email",
+			"type":                  "direct",
+			"is_primary_identifier": true,
+		},
+		map[string]interface{}{
+			"to":       "Source",
+			"type":     "constant",
+			"constant": "Website",
+		},
+		map[string]interface{}{
+			"to":              "SyncRunID",
+			"type":            "sync_metadata",
+			"sync_metadata_key": "sync_run_id",
+		},
+		map[string]interface{}{
+			"to":              "FullName",
+			"type":            "liquid_template",
+			"liquid_template": "{{ first_name }} {{ last_name }}",
+		},
+	}
+
+	// API returns in completely different order
+	apiMappings := []client.FieldMapping{
+		{
+			To:             "FullName",
+			Type:           "liquid_template",
+			LiquidTemplate: "{{ first_name }} {{ last_name }}",
+		},
+		{
+			From:                "email",
+			To:                  "Email",
+			Type:                "direct",
+			IsPrimaryIdentifier: true,
+		},
+		{
+			To:              "SyncRunID",
+			Type:            "sync_metadata",
+			SyncMetadataKey: "sync_run_id",
+		},
+		{
+			To:       "Source",
+			Type:     "constant",
+			Constant: "Website",
+		},
+	}
+
+	result := provider.MatchFieldMappingsByTo(stateMappings, apiMappings)
+
+	// Verify result has all 4 mappings
+	if len(result) != 4 {
+		t.Errorf("Expected 4 mappings, got %d", len(result))
+	}
+
+	// Verify order matches state
+	expectedOrder := []string{"Email", "Source", "SyncRunID", "FullName"}
+	for i, mapping := range result {
+		if mapping.To != expectedOrder[i] {
+			t.Errorf("Result[%d].To = %s, want %s", i, mapping.To, expectedOrder[i])
+		}
+	}
+
+	// Verify types are preserved
+	if result[0].Type != "direct" || !result[0].IsPrimaryIdentifier {
+		t.Errorf("Email mapping should be direct type with primary identifier")
+	}
+	if result[1].Type != "constant" {
+		t.Errorf("Source mapping should be constant type")
+	}
+	if result[2].Type != "sync_metadata" {
+		t.Errorf("SyncRunID mapping should be sync_metadata type")
+	}
+	if result[3].Type != "liquid_template" {
+		t.Errorf("FullName mapping should be liquid_template type")
+	}
+}
+
+func TestMatchFieldMappingsByTo_EmptyState(t *testing.T) {
+	// State is empty (new resource)
+	stateMappings := []interface{}{}
+
+	// API returns mappings
+	apiMappings := []client.FieldMapping{
+		{
+			From: "email",
+			To:   "Email",
+			Type: "direct",
+		},
+		{
+			From: "first_name",
+			To:   "FirstName",
+			Type: "direct",
+		},
+	}
+
+	result := provider.MatchFieldMappingsByTo(stateMappings, apiMappings)
+
+	// Should return all API mappings in their original order
+	if len(result) != 2 {
+		t.Errorf("Expected 2 mappings, got %d", len(result))
+	}
+	if !reflect.DeepEqual(result, apiMappings) {
+		t.Errorf("With empty state, should return API mappings unchanged")
+	}
+}
+
+func TestMatchFieldMappingsByTo_EmptyAPI(t *testing.T) {
+	// State has mappings
+	stateMappings := []interface{}{
+		map[string]interface{}{
+			"from": "email",
+			"to":   "Email",
+		},
+	}
+
+	// API returns no mappings
+	apiMappings := []client.FieldMapping{}
+
+	result := provider.MatchFieldMappingsByTo(stateMappings, apiMappings)
+
+	// Should return empty result
+	if len(result) != 0 {
+		t.Errorf("Expected 0 mappings, got %d", len(result))
+	}
+}
+
+func TestMatchFieldMappingsByTo_BothEmpty(t *testing.T) {
+	stateMappings := []interface{}{}
+	apiMappings := []client.FieldMapping{}
+
+	result := provider.MatchFieldMappingsByTo(stateMappings, apiMappings)
+
+	// Should return empty result
+	if len(result) != 0 {
+		t.Errorf("Expected 0 mappings, got %d", len(result))
+	}
+}
+
+// ============================================================================
 // Alert Tests
 // ============================================================================
 


### PR DESCRIPTION
# Fix field mapping order drift in Terraform provider

## Problem

Customers using the Terraform provider were seeing spurious diffs during `terraform plan` for field mappings, even
 when nothing had changed. This was caused by:

1. The Census API not guaranteeing a consistent order when returning field mappings in GET responses
2. Terraform treating `field_mapping` as an ordered list (TypeList), so any order change triggered a diff
3. The customer specifically uses `field_order = "mapping_order"` where order is critical to sync behavior

## Solution

**Census API Changes:**
- Expose the `position` field in field mapping API responses 
- Position is set **regardless** of the `field_order` setting (works for both `"mapping_order"` and
`"alphabetical_column_name"`)

**Terraform Provider Changes:**
- Add `Position int` field to the `FieldMapping` client struct
- Sort API responses by `position` before comparing to Terraform state
- Position is **not** exposed in the Terraform schema - it's only used internally for sorting

## Benefits

✅ Eliminates false positive diffs when nothing has changed
✅ Uses Census's canonical source of truth for ordering
✅ Works correctly for all `field_order` values
✅ Detects real changes (if someone reorders mappings in Census UI)
✅ No breaking changes - backward compatible

## Deployment Notes

1. Deploy Census API changes first (adds position field)
2. Release Terraform provider v0.2.9
3. Old provider versions will continue to work (they just won't use the new position field)
4. No user action required - no breaking changes