### PR TITLE
Cache workspace API tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.11] - 2026-03-06
+
+### Changed
+- **Workspace Token Caching**: Workspace API keys are now cached in-memory for the duration of a Terraform run, eliminating redundant API calls to fetch the same workspace token before every resource operation. This significantly reduces API overhead when managing multiple resources in the same workspace.
+
 ## [0.2.10] - 2026-01-30
 
 ### Added

--- a/census/client/client.go
+++ b/census/client/client.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -37,6 +38,11 @@ type Config struct {
 type Client struct {
 	config     *Config
 	httpClient *http.Client
+
+	// workspaceTokenCache caches workspace API keys by workspace ID to avoid
+	// redundant API calls during a single Terraform run. Protected by tokenMu.
+	tokenMu             sync.RWMutex
+	workspaceTokenCache map[int]string
 }
 
 // NewClient creates a new Census API client
@@ -57,8 +63,9 @@ func NewClient(config *Config) (*Client, error) {
 	}
 
 	return &Client{
-		config:     config,
-		httpClient: httpClient,
+		config:              config,
+		httpClient:          httpClient,
+		workspaceTokenCache: make(map[int]string),
 	}, nil
 }
 

--- a/census/client/workspace.go
+++ b/census/client/workspace.go
@@ -151,9 +151,20 @@ type WorkspaceAPIKeyResponse struct {
 	APIKey string `json:"api_key"`
 }
 
-// GetWorkspaceAPIKey retrieves the API key for a specific workspace
-// Requires organization-level permissions (personal access token)
+// GetWorkspaceAPIKey retrieves the API key for a specific workspace.
+// Results are cached for the lifetime of the client to avoid redundant API calls
+// during a single Terraform run.
+// Requires organization-level permissions (personal access token).
 func (c *Client) GetWorkspaceAPIKey(ctx context.Context, workspaceID int) (string, error) {
+	// Check cache first (read lock)
+	c.tokenMu.RLock()
+	if token, ok := c.workspaceTokenCache[workspaceID]; ok {
+		c.tokenMu.RUnlock()
+		return token, nil
+	}
+	c.tokenMu.RUnlock()
+
+	// Cache miss — fetch from API
 	path := fmt.Sprintf("/workspaces/%d/api_key", workspaceID)
 	resp, err := c.makeRequest(ctx, http.MethodGet, path, nil, TokenTypePersonal)
 	if err != nil {
@@ -164,6 +175,11 @@ func (c *Client) GetWorkspaceAPIKey(ctx context.Context, workspaceID int) (strin
 	if err := c.handleResponse(resp, &result); err != nil {
 		return "", fmt.Errorf("failed to get workspace API key: %w", err)
 	}
+
+	// Store in cache (write lock)
+	c.tokenMu.Lock()
+	c.workspaceTokenCache[workspaceID] = result.APIKey
+	c.tokenMu.Unlock()
 
 	return result.APIKey, nil
 }


### PR DESCRIPTION
## Context
We make an API call to fetch the workspace token for every CRUD operation on every resource on a terraform plan or apply. This is super wasteful, considering this is usually all going into 1 workspace (maybe a few)

## What changed

Only two files were modified — no resource files needed changes since they all call the same GetWorkspaceAPIKey
method.

census/client/client.go:
- Added sync import
- Added tokenMu sync.RWMutex and workspaceTokenCache map[int]string fields to the Client struct
- Initialized the cache map in NewClient()

census/client/workspace.go:
- GetWorkspaceAPIKey() now checks the cache (under a read lock) before making an API call. On a cache miss it
fetches from the API as before, then stores the result (under a write lock) for subsequent calls.

## How it works

- First call for a given workspaceID hits the API normally and caches the token.
- All subsequent calls for the same workspace ID return the cached token instantly — no API request.
- The cache lives for the lifetime of the Client (i.e., a single terraform plan/apply run), so there's no risk of
stale tokens persisting across runs.
- sync.RWMutex ensures thread safety since Terraform may run resource operations concurrently.