### PR TITLE
RD-1191626: add configurable sync_engine support for census_source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Configurable Source Sync Engine**: Added a `sync_engine` argument to `census_source`, allowing Terraform users to request the `advanced` sync engine at creation time for supported source types such as Snowflake Warehouse Writeback. The field defaults to `basic`, is stored in state when returned by the Census API, and forces source recreation when changed.
+- **Configurable Source Sync Engine**: Added a `sync_engine` argument to `census_source`, allowing Terraform users to request either engine explicitly for supported source types such as Snowflake Warehouse Writeback.
+
+### Changed
+- **Advanced Source Engine by Default**: `census_source` now defaults `sync_engine` to `advanced` to match the Census UI. The field is stored in state when returned by the Census API and still forces source recreation when changed.
 
 ## [0.2.11] - 2026-03-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Configurable Source Sync Engine**: Added a `sync_engine` argument to `census_source`, allowing Terraform users to request either engine explicitly for supported source types such as Snowflake Warehouse Writeback.
 
 ### Changed
-- **Advanced Source Engine by Default**: `census_source` now defaults `sync_engine` to `advanced` to match the Census UI. The field is stored in state when returned by the Census API and still forces source recreation when changed.
+- **Advanced Source Engine by Default**: `census_source` now defaults `sync_engine` to `advanced` to match the Census UI. The field is stored in state when returned by the Census API and still forces source recreation when changed, because the Census API rejects in-place sync engine updates.
 
 ## [0.2.11] - 2026-03-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Configurable Source Sync Engine**: Added a `sync_engine` argument to `census_source`, allowing Terraform users to request the `advanced` sync engine at creation time for supported source types such as Snowflake Warehouse Writeback. The field defaults to `basic`, is stored in state when returned by the Census API, and forces source recreation when changed.
+
 ## [0.2.11] - 2026-03-06
 
 ### Changed

--- a/census/client/source.go
+++ b/census/client/source.go
@@ -13,6 +13,7 @@ type Source struct {
 	WorkspaceID string                 `json:"workspace_id,omitempty"`
 	Name        string                 `json:"name"`
 	Type        string                 `json:"type"`
+	SyncEngine  string                 `json:"sync_engine,omitempty"`
 	CreatedAt   time.Time              `json:"created_at"`
 	UpdatedAt   time.Time              `json:"updated_at"`
 	Connection  map[string]interface{} `json:"connection"`

--- a/census/provider/resource_source.go
+++ b/census/provider/resource_source.go
@@ -56,6 +56,13 @@ func resourceSource() *schema.Resource {
 				ForceNew:    true,
 				Description: "The type of source (e.g., snowflake, bigquery, postgres).",
 			},
+			"sync_engine": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "basic",
+				ForceNew:    true,
+				Description: "The sync engine to use for the source. Set to `advanced` for features like Warehouse Writeback when supported by the source type.",
+			},
 			"connection_config": {
 				Type:        schema.TypeMap,
 				Required:    true,
@@ -104,6 +111,7 @@ func resourceSourceCreate(ctx context.Context, d *schema.ResourceData, meta inte
 	workspaceId := d.Get("workspace_id").(string)
 	name := d.Get("name").(string)
 	sourceType := d.Get("type").(string)
+	syncEngine := d.Get("sync_engine").(string)
 	connectionConfig := expandConnectionConfig(d.Get("connection_config").(map[string]interface{}))
 
 	// Get the workspace API key dynamically using the personal access token
@@ -129,7 +137,7 @@ func resourceSourceCreate(ctx context.Context, d *schema.ResourceData, meta inte
 		Connection: client.SourceConnection{
 			Name:        name, // Set name inside connection per API requirements
 			Type:        sourceType,
-			SyncEngine:  "basic", // Default sync engine
+			SyncEngine:  syncEngine,
 			Credentials: connectionConfig,
 		},
 	}
@@ -211,6 +219,9 @@ Where 69962 is the workspace_id for marketing_prod workspace.`)
 	if source.WorkspaceID != "" {
 		d.Set("workspace_id", source.WorkspaceID)
 	}
+	if syncEngine := getSourceSyncEngine(source); syncEngine != "" {
+		d.Set("sync_engine", syncEngine)
+	}
 	d.Set("name", source.Name)
 	d.Set("type", source.Type)
 	d.Set("status", source.Status)
@@ -227,6 +238,27 @@ Where 69962 is the workspace_id for marketing_prod workspace.`)
 	// Terraform will maintain the connection config from the configuration
 
 	return nil
+}
+
+func getSourceSyncEngine(source *client.Source) string {
+	if source == nil {
+		return ""
+	}
+
+	if source.SyncEngine != "" {
+		return source.SyncEngine
+	}
+
+	if source.Connection == nil {
+		return ""
+	}
+
+	syncEngine, ok := source.Connection["sync_engine"].(string)
+	if !ok {
+		return ""
+	}
+
+	return syncEngine
 }
 
 func resourceSourceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/census/provider/resource_source.go
+++ b/census/provider/resource_source.go
@@ -59,9 +59,9 @@ func resourceSource() *schema.Resource {
 			"sync_engine": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Default:     "basic",
+				Default:     "advanced",
 				ForceNew:    true,
-				Description: "The sync engine to use for the source. Set to `advanced` for features like Warehouse Writeback when supported by the source type.",
+				Description: "The sync engine to use for the source. Defaults to `advanced` to match the Census UI. Set to `basic` when a source type or workflow requires it.",
 			},
 			"connection_config": {
 				Type:        schema.TypeMap,

--- a/census/provider/resource_source_test.go
+++ b/census/provider/resource_source_test.go
@@ -48,6 +48,23 @@ func TestResourceSourceCreate_UsesConfiguredSyncEngine(t *testing.T) {
 	}
 }
 
+func TestResourceSourceCreate_UsesBasicSyncEngineWhenConfigured(t *testing.T) {
+	t.Parallel()
+
+	capturedSyncEngine, diags, d := runSourceCreateTest(t, "basic")
+	if diags.HasError() {
+		t.Fatalf("expected source creation to succeed, got diagnostics: %#v", diags)
+	}
+
+	if capturedSyncEngine != "basic" {
+		t.Fatalf("expected create request to use basic sync engine, got %q", capturedSyncEngine)
+	}
+
+	if got := d.Get("sync_engine").(string); got != "basic" {
+		t.Fatalf("expected state to retain basic sync engine, got %q", got)
+	}
+}
+
 func TestResourceSourceRead_UpdatesSyncEngineFromAPI(t *testing.T) {
 	t.Parallel()
 

--- a/census/provider/resource_source_test.go
+++ b/census/provider/resource_source_test.go
@@ -88,6 +88,19 @@ func TestResourceSourceRead_UpdatesSyncEngineFromAPI(t *testing.T) {
 	}
 }
 
+func TestResourceSourceSchema_SyncEngineIsForceNew(t *testing.T) {
+	t.Parallel()
+
+	syncEngineField := resourceSource().Schema["sync_engine"]
+	if syncEngineField == nil {
+		t.Fatal("expected sync_engine field to exist on census_source")
+	}
+
+	if !syncEngineField.ForceNew {
+		t.Fatal("expected sync_engine to be ForceNew because the Census API does not allow in-place sync engine changes")
+	}
+}
+
 func runSourceCreateTest(t *testing.T, syncEngine string) (string, diag.Diagnostics, *schema.ResourceData) {
 	t.Helper()
 

--- a/census/provider/resource_source_test.go
+++ b/census/provider/resource_source_test.go
@@ -1,0 +1,199 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/sutrolabs/terraform-provider-census/census/client"
+)
+
+func TestResourceSourceCreate_DefaultsSyncEngineToBasic(t *testing.T) {
+	t.Parallel()
+
+	capturedSyncEngine, diags, d := runSourceCreateTest(t, "")
+	if diags.HasError() {
+		t.Fatalf("expected source creation to succeed, got diagnostics: %#v", diags)
+	}
+
+	if capturedSyncEngine != "basic" {
+		t.Fatalf("expected create request to use basic sync engine, got %q", capturedSyncEngine)
+	}
+
+	if got := d.Get("sync_engine").(string); got != "basic" {
+		t.Fatalf("expected state to keep default basic sync engine, got %q", got)
+	}
+}
+
+func TestResourceSourceCreate_UsesConfiguredSyncEngine(t *testing.T) {
+	t.Parallel()
+
+	capturedSyncEngine, diags, d := runSourceCreateTest(t, "advanced")
+	if diags.HasError() {
+		t.Fatalf("expected source creation to succeed, got diagnostics: %#v", diags)
+	}
+
+	if capturedSyncEngine != "advanced" {
+		t.Fatalf("expected create request to use advanced sync engine, got %q", capturedSyncEngine)
+	}
+
+	if got := d.Get("sync_engine").(string); got != "advanced" {
+		t.Fatalf("expected state to retain advanced sync engine, got %q", got)
+	}
+}
+
+func TestResourceSourceRead_UpdatesSyncEngineFromAPI(t *testing.T) {
+	t.Parallel()
+
+	const (
+		workspaceID = 69962
+		sourceID    = 2280673
+	)
+
+	apiClient := newSourceTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/workspaces/69962/api_key":
+			writeJSON(t, w, http.StatusOK, map[string]string{"api_key": "workspace-token"})
+		case "/sources/2280673":
+			if r.Method != http.MethodGet {
+				t.Fatalf("unexpected method for %s: %s", r.URL.Path, r.Method)
+			}
+			writeJSON(t, w, http.StatusOK, buildSourceResponse(sourceID, "advanced"))
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	d := schema.TestResourceDataRaw(t, resourceSource().Schema, map[string]interface{}{
+		"workspace_id":      strconv.Itoa(workspaceID),
+		"name":              "Warehouse Source",
+		"type":              "snowflake",
+		"connection_config": map[string]interface{}{"account": "acct"},
+	})
+	d.SetId(strconv.Itoa(sourceID))
+
+	diags := resourceSourceRead(context.Background(), d, apiClient)
+	if diags.HasError() {
+		t.Fatalf("expected source read to succeed, got diagnostics: %#v", diags)
+	}
+
+	if got := d.Get("sync_engine").(string); got != "advanced" {
+		t.Fatalf("expected read to update sync_engine from API response, got %q", got)
+	}
+}
+
+func runSourceCreateTest(t *testing.T, syncEngine string) (string, diag.Diagnostics, *schema.ResourceData) {
+	t.Helper()
+
+	const (
+		workspaceID = 69962
+		sourceID    = 2280673
+	)
+
+	var capturedSyncEngine string
+
+	apiClient := newSourceTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/workspaces/69962/api_key":
+			writeJSON(t, w, http.StatusOK, map[string]string{"api_key": "workspace-token"})
+		case "/source_types":
+			writeJSON(t, w, http.StatusOK, map[string]interface{}{
+				"status": "success",
+				"data": []map[string]interface{}{
+					{
+						"service_name": "snowflake",
+						"configuration_fields": map[string]interface{}{
+							"fields": []map[string]interface{}{},
+						},
+					},
+				},
+			})
+		case "/sources":
+			if r.Method != http.MethodPost {
+				t.Fatalf("unexpected method for %s: %s", r.URL.Path, r.Method)
+			}
+
+			var req client.CreateSourceRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatalf("failed to decode create source request: %v", err)
+			}
+			capturedSyncEngine = req.Connection.SyncEngine
+
+			writeJSON(t, w, http.StatusOK, buildSourceResponse(sourceID, req.Connection.SyncEngine))
+		case "/sources/2280673":
+			if r.Method != http.MethodGet {
+				t.Fatalf("unexpected method for %s: %s", r.URL.Path, r.Method)
+			}
+			writeJSON(t, w, http.StatusOK, buildSourceResponse(sourceID, capturedSyncEngine))
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	raw := map[string]interface{}{
+		"workspace_id":      strconv.Itoa(workspaceID),
+		"name":              "Warehouse Source",
+		"type":              "snowflake",
+		"connection_config": map[string]interface{}{"account": "acct"},
+	}
+	if syncEngine != "" {
+		raw["sync_engine"] = syncEngine
+	}
+
+	d := schema.TestResourceDataRaw(t, resourceSource().Schema, raw)
+	diags := resourceSourceCreate(context.Background(), d, apiClient)
+
+	return capturedSyncEngine, diags, d
+}
+
+func newSourceTestClient(t *testing.T, handler http.HandlerFunc) *client.Client {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	apiClient, err := client.NewClient(&client.Config{
+		BaseURL:             server.URL,
+		PersonalAccessToken: "personal-token",
+	})
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	return apiClient
+}
+
+func buildSourceResponse(sourceID int, syncEngine string) map[string]interface{} {
+	return map[string]interface{}{
+		"status": "success",
+		"data": map[string]interface{}{
+			"id":          sourceID,
+			"name":        "Warehouse Source",
+			"type":        "snowflake",
+			"sync_engine": syncEngine,
+			"connection": map[string]interface{}{
+				"sync_engine": syncEngine,
+			},
+			"status":      "connected",
+			"test_status": "passed",
+			"created_at":  "2026-04-09T22:00:00Z",
+			"updated_at":  "2026-04-09T22:05:00Z",
+		},
+	}
+}
+
+func writeJSON(t *testing.T, w http.ResponseWriter, statusCode int, payload interface{}) {
+	t.Helper()
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
+	if err := json.NewEncoder(w).Encode(payload); err != nil {
+		t.Fatalf("failed to encode response: %v", err)
+	}
+}

--- a/census/provider/resource_source_test.go
+++ b/census/provider/resource_source_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/sutrolabs/terraform-provider-census/census/client"
 )
 
-func TestResourceSourceCreate_DefaultsSyncEngineToBasic(t *testing.T) {
+func TestResourceSourceCreate_DefaultsSyncEngineToAdvanced(t *testing.T) {
 	t.Parallel()
 
 	capturedSyncEngine, diags, d := runSourceCreateTest(t, "")
@@ -22,12 +22,12 @@ func TestResourceSourceCreate_DefaultsSyncEngineToBasic(t *testing.T) {
 		t.Fatalf("expected source creation to succeed, got diagnostics: %#v", diags)
 	}
 
-	if capturedSyncEngine != "basic" {
-		t.Fatalf("expected create request to use basic sync engine, got %q", capturedSyncEngine)
+	if capturedSyncEngine != "advanced" {
+		t.Fatalf("expected create request to default to advanced sync engine, got %q", capturedSyncEngine)
 	}
 
-	if got := d.Get("sync_engine").(string); got != "basic" {
-		t.Fatalf("expected state to keep default basic sync engine, got %q", got)
+	if got := d.Get("sync_engine").(string); got != "advanced" {
+		t.Fatalf("expected state to keep default advanced sync engine, got %q", got)
 	}
 }
 

--- a/docs/resources/source.md
+++ b/docs/resources/source.md
@@ -141,5 +141,5 @@ terraform import census_source.warehouse "12345:67890"
 * The `connection_config` field is marked as sensitive and will not be displayed in Terraform output.
 * Source types and required credential fields are validated against the Census API's `/source_types` endpoint.
 * After creation, the provider automatically triggers a table refresh to discover available tables.
-* `sync_engine` is a create-time setting. Changing it in Terraform recreates the source so the Census API can provision the requested engine cleanly.
+* `sync_engine` is a create-time setting. The Census API rejects in-place sync engine changes with a 4xx response, so Terraform recreates the source when this field changes.
 * Leaving `sync_engine` unset now creates sources with the advanced engine by default, which is the recommended path for newer workflows like Warehouse Writeback.

--- a/docs/resources/source.md
+++ b/docs/resources/source.md
@@ -23,14 +23,14 @@ resource "census_source" "warehouse" {
 }
 ```
 
-### Snowflake Source (Advanced Sync Engine)
+### Snowflake Source (Explicit Basic Sync Engine)
 
 ```hcl
-resource "census_source" "warehouse_writeback" {
+resource "census_source" "warehouse_basic" {
   workspace_id = census_workspace.main.id
-  name         = "Warehouse Writeback Source"
+  name         = "Warehouse Source (Basic Engine)"
   type         = "snowflake"
-  sync_engine  = "advanced"
+  sync_engine  = "basic"
 
   connection_config = {
     account   = "abc12345.us-east-1"
@@ -110,7 +110,7 @@ resource "census_source" "postgres" {
   - `databricks`
   - `mysql`
   - And many more... (validated against Census API)
-* `sync_engine` - (Optional, Forces new resource) The sync engine to use when the source is created. Defaults to `basic`. Set this to `advanced` for features like Warehouse Writeback when the selected source type supports it.
+* `sync_engine` - (Optional, Forces new resource) The sync engine to use when the source is created. Defaults to `advanced` to match the Census UI. Set this to `basic` only when you explicitly need the basic engine.
 * `connection_config` - (Required, Sensitive) Map of credentials for connecting to the source. Supports strings, numbers, and booleans. The required fields vary by source type and are validated against the Census API schema.
 
 ## Attribute Reference
@@ -142,3 +142,4 @@ terraform import census_source.warehouse "12345:67890"
 * Source types and required credential fields are validated against the Census API's `/source_types` endpoint.
 * After creation, the provider automatically triggers a table refresh to discover available tables.
 * `sync_engine` is a create-time setting. Changing it in Terraform recreates the source so the Census API can provision the requested engine cleanly.
+* Leaving `sync_engine` unset now creates sources with the advanced engine by default, which is the recommended path for newer workflows like Warehouse Writeback.

--- a/docs/resources/source.md
+++ b/docs/resources/source.md
@@ -23,6 +23,26 @@ resource "census_source" "warehouse" {
 }
 ```
 
+### Snowflake Source (Advanced Sync Engine)
+
+```hcl
+resource "census_source" "warehouse_writeback" {
+  workspace_id = census_workspace.main.id
+  name         = "Warehouse Writeback Source"
+  type         = "snowflake"
+  sync_engine  = "advanced"
+
+  connection_config = {
+    account   = "abc12345.us-east-1"
+    warehouse = "COMPUTE_WH"
+    database  = "PRODUCTION"
+    username  = "census_user"
+    password  = var.snowflake_password
+    role      = "CENSUS_ROLE"
+  }
+}
+```
+
 ### Snowflake Source (Keypair Authentication)
 
 ```hcl
@@ -90,6 +110,7 @@ resource "census_source" "postgres" {
   - `databricks`
   - `mysql`
   - And many more... (validated against Census API)
+* `sync_engine` - (Optional, Forces new resource) The sync engine to use when the source is created. Defaults to `basic`. Set this to `advanced` for features like Warehouse Writeback when the selected source type supports it.
 * `connection_config` - (Required, Sensitive) Map of credentials for connecting to the source. Supports strings, numbers, and booleans. The required fields vary by source type and are validated against the Census API schema.
 
 ## Attribute Reference
@@ -99,6 +120,7 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The ID of the source.
 * `status` - The current status of the source.
 * `test_status` - The test status of the source connection.
+* `sync_engine` - The sync engine configured for the source when it is returned by the Census API.
 
 ## Import
 
@@ -119,3 +141,4 @@ terraform import census_source.warehouse "12345:67890"
 * The `connection_config` field is marked as sensitive and will not be displayed in Terraform output.
 * Source types and required credential fields are validated against the Census API's `/source_types` endpoint.
 * After creation, the provider automatically triggers a table refresh to discover available tables.
+* `sync_engine` is a create-time setting. Changing it in Terraform recreates the source so the Census API can provision the requested engine cleanly.


### PR DESCRIPTION
## Summary
- add a `sync_engine` argument to `census_source`, defaulting to `advanced` and forcing recreation when changed
- pass the configured sync engine through to source creation instead of hardcoding `basic`
- preserve `sync_engine` in state when the Census API returns it, and document the advanced-engine Snowflake/Warehouse Writeback use case
- add provider unit tests covering default/basic, explicit advanced, and read-state hydration

## Context
Zendesk 371085 reported that the provider always created Snowflake sources with `sync_engine = "basic"`, which blocked Warehouse Writeback because that flow requires the advanced sync engine.

## Testing
- `env GOCACHE=/tmp/go-build-cache go test ./census/provider -run 'TestResourceSource|TestResourceReads'`
- `env GOCACHE=/tmp/go-build-cache go test ./census/tests/client -run TestValidateSourceCredentials`
