### PR TITLE
Hotfix unintended census_source replacements from 0.2.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.13] - 2026-04-21
+
+### Fixed
+- **Existing Source Sync Engine Preservation**: `census_source` no longer treats an omitted `sync_engine` argument as an instruction to replace existing sources during provider upgrades. New sources still default to `advanced`, but existing managed sources now keep their current engine unless `sync_engine` is set explicitly in configuration.
+
+### Upgrade Guidance
+- If you are on `0.2.12`, upgrade directly to `0.2.13`.
+- Avoid applying `0.2.12` when `census_source.sync_engine` is omitted from configuration.
+- If you need time before upgrading, pin to `0.2.11`.
+
+## [0.2.12] - 2026-04-15
+
+### Warning
+- **Known Issue**: `0.2.12` can plan replacement of existing `census_source` resources when `sync_engine` is omitted from configuration. Because `sync_engine` is immutable and forces source recreation, this can affect downstream sync history. Upgrade to `0.2.13` instead.
 
 ### Added
 - **Configurable Source Sync Engine**: Added a `sync_engine` argument to `census_source`, allowing Terraform users to request either engine explicitly for supported source types such as Snowflake Warehouse Writeback.
@@ -170,7 +183,7 @@ terraform {
   required_providers {
     census = {
       source  = "sutrolabs/census"
-      version = "~> 0.2.0"
+      version = "!= 0.2.12, ~> 0.2.0"
     }
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **Advanced Source Engine by Default**: `census_source` now defaults `sync_engine` to `advanced` to match the Census UI. The field is stored in state when returned by the Census API and still forces source recreation when changed, because the Census API rejects in-place sync engine updates.
 
+### Fixed
+- **Resource Read Error Handling**: Fixed `census_destination`, `census_source`, `census_dataset`, and `census_sync` read paths to preserve API read errors instead of silently clearing Terraform state. A shadowed `err` variable in the workspace-token lookup block caused `504` and timeout-style read failures to fall through to the `nil` resource branch, which could make Terraform treat an existing resource as missing and attempt to recreate it. The provider now correctly hard-fails on read errors while still clearing state for confirmed `404` responses.
+
 ## [0.2.11] - 2026-03-06
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -12,12 +12,14 @@ A Terraform provider for managing [Census](https://getcensus.com) resources. Cen
 
 ## Installation
 
+> Warning: Avoid `0.2.12` if you manage any existing `census_source` resources with `sync_engine` omitted from configuration. `0.2.12` can plan source replacement for those resources, which may affect downstream sync history. Upgrade to `0.2.13` instead, or pin to `0.2.11` until you can upgrade safely.
+
 ```hcl
 terraform {
   required_providers {
     census = {
       source  = "sutrolabs/census"
-      version = "~> 0.2.0"
+      version = "!= 0.2.12, ~> 0.2.0"
     }
   }
 }

--- a/census/provider/resource_source.go
+++ b/census/provider/resource_source.go
@@ -59,9 +59,9 @@ func resourceSource() *schema.Resource {
 			"sync_engine": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Default:     "advanced",
+				Computed:    true,
 				ForceNew:    true,
-				Description: "The sync engine to use for the source. Defaults to `advanced` to match the Census UI. Set to `basic` when a source type or workflow requires it.",
+				Description: "The sync engine to use for the source. New sources default to `advanced` to match the Census UI. Leave this unset to preserve the current engine on existing sources, or set it explicitly to `basic` or `advanced` to manage it in Terraform.",
 			},
 			"connection_config": {
 				Type:        schema.TypeMap,
@@ -111,7 +111,7 @@ func resourceSourceCreate(ctx context.Context, d *schema.ResourceData, meta inte
 	workspaceId := d.Get("workspace_id").(string)
 	name := d.Get("name").(string)
 	sourceType := d.Get("type").(string)
-	syncEngine := d.Get("sync_engine").(string)
+	syncEngine := getConfiguredSourceSyncEngine(d)
 	connectionConfig := expandConnectionConfig(d.Get("connection_config").(map[string]interface{}))
 
 	// Get the workspace API key dynamically using the personal access token
@@ -259,6 +259,16 @@ func getSourceSyncEngine(source *client.Source) string {
 	}
 
 	return syncEngine
+}
+
+func getConfiguredSourceSyncEngine(d *schema.ResourceData) string {
+	if syncEngine, ok := d.GetOk("sync_engine"); ok {
+		if configuredSyncEngine := syncEngine.(string); configuredSyncEngine != "" {
+			return configuredSyncEngine
+		}
+	}
+
+	return "advanced"
 }
 
 func resourceSourceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/census/provider/resource_source_test.go
+++ b/census/provider/resource_source_test.go
@@ -17,6 +17,10 @@ import (
 func TestResourceSourceCreate_DefaultsSyncEngineToAdvanced(t *testing.T) {
 	t.Parallel()
 
+	if got := resourceSource().Schema["sync_engine"].Default; got != nil {
+		t.Fatalf("expected sync_engine schema default to be unset, got %#v", got)
+	}
+
 	capturedSyncEngine, diags, d := runSourceCreateTest(t, "")
 	if diags.HasError() {
 		t.Fatalf("expected source creation to succeed, got diagnostics: %#v", diags)
@@ -115,6 +119,57 @@ func TestResourceSourceSchema_SyncEngineIsForceNew(t *testing.T) {
 
 	if !syncEngineField.ForceNew {
 		t.Fatal("expected sync_engine to be ForceNew because the Census API does not allow in-place sync engine changes")
+	}
+
+	if !syncEngineField.Computed {
+		t.Fatal("expected sync_engine to be Computed so existing sources can preserve their current engine when the argument is omitted")
+	}
+}
+
+func TestGetConfiguredSourceSyncEngine(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name       string
+		configured interface{}
+		want       string
+	}{
+		{
+			name: "omitted defaults to advanced on create",
+			want: "advanced",
+		},
+		{
+			name:       "explicit basic is preserved",
+			configured: "basic",
+			want:       "basic",
+		},
+		{
+			name:       "explicit advanced is preserved",
+			configured: "advanced",
+			want:       "advanced",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			raw := map[string]interface{}{
+				"workspace_id":      "69962",
+				"name":              "Warehouse Source",
+				"type":              "snowflake",
+				"connection_config": map[string]interface{}{"account": "acct"},
+			}
+			if tc.configured != nil {
+				raw["sync_engine"] = tc.configured
+			}
+
+			d := schema.TestResourceDataRaw(t, resourceSource().Schema, raw)
+			if got := getConfiguredSourceSyncEngine(d); got != tc.want {
+				t.Fatalf("expected configured sync engine %q, got %q", tc.want, got)
+			}
+		})
 	}
 }
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,8 @@ description: |-
 
 The Census provider allows you to manage [Census](https://getcensus.com) resources using Terraform. Census enables you to sync data from your warehouse to all your operational tools, and this provider allows you to manage Census infrastructure as code.
 
+> Warning: Avoid `0.2.12` if you manage any existing `census_source` resources with `sync_engine` omitted from configuration. `0.2.12` can plan source replacement for those resources, which may affect downstream sync history. Upgrade to `0.2.13` instead, or pin to `0.2.11` until you can upgrade safely.
+
 ## Example Usage
 
 ```terraform
@@ -16,7 +18,7 @@ terraform {
   required_providers {
     census = {
       source  = "sutrolabs/census"
-      version = "~> 0.2.0"
+      version = "!= 0.2.12, ~> 0.2.0"
     }
   }
 }

--- a/docs/resources/source.md
+++ b/docs/resources/source.md
@@ -2,6 +2,8 @@
 
 Manages a Census data source connection. Sources connect to data warehouses like Snowflake, BigQuery, Postgres, and others.
 
+> Warning: Avoid provider version `0.2.12` if this resource omits `sync_engine`. `0.2.12` can plan replacement of existing `census_source` resources that were created before `sync_engine` support was added, which may affect downstream sync history. Upgrade to `0.2.13` instead, or pin to `0.2.11` until you can upgrade safely.
+
 ## Example Usage
 
 ### Snowflake Source (Password Authentication)
@@ -110,7 +112,7 @@ resource "census_source" "postgres" {
   - `databricks`
   - `mysql`
   - And many more... (validated against Census API)
-* `sync_engine` - (Optional, Forces new resource) The sync engine to use when the source is created. Defaults to `advanced` to match the Census UI. Set this to `basic` only when you explicitly need the basic engine.
+* `sync_engine` - (Optional, Computed, Forces new resource) The sync engine to use when the source is created. New sources default to `advanced` to match the Census UI. Leave this unset to preserve the current engine on existing sources, or set it explicitly to `basic` only when you need the basic engine.
 * `connection_config` - (Required, Sensitive) Map of credentials for connecting to the source. Supports strings, numbers, and booleans. The required fields vary by source type and are validated against the Census API schema.
 
 ## Attribute Reference
@@ -142,4 +144,5 @@ terraform import census_source.warehouse "12345:67890"
 * Source types and required credential fields are validated against the Census API's `/source_types` endpoint.
 * After creation, the provider automatically triggers a table refresh to discover available tables.
 * `sync_engine` is a create-time setting. The Census API rejects in-place sync engine changes with a 4xx response, so Terraform recreates the source when this field changes.
-* Leaving `sync_engine` unset now creates sources with the advanced engine by default, which is the recommended path for newer workflows like Warehouse Writeback.
+* Leaving `sync_engine` unset creates new sources with the advanced engine by default, but preserves the current engine for existing managed sources to avoid unexpected replacements during provider upgrades.
+* If you already use `sync_engine`, set it explicitly in configuration so future provider upgrades cannot infer a different value from a changing default.


### PR DESCRIPTION
## Summary
This hotfix addresses a regression introduced in `0.2.12` where existing `census_source` resources could be planned for replacement when `sync_engine` was omitted from configuration.

In `0.2.12`, changing the default behavior of an omitted `sync_engine` on an immutable (`ForceNew`) field caused Terraform to infer `advanced` for existing sources that were previously created without the argument. That could force source recreation and affect downstream sync history.

## What changed
- Preserve the current source sync engine for existing managed sources when `sync_engine` is omitted
- Continue defaulting new source creates to `advanced`
- Keep explicit `sync_engine = "basic"` and `sync_engine = "advanced"` behavior unchanged
- Add regression test coverage for omitted, explicit basic, and explicit advanced create paths
- Update docs and changelog to:
  - warn users away from `0.2.12`
  - document the known issue under `0.2.12`
  - position this fix as the `0.2.13` upgrade path

## Why this approach
This restores backward-compatible behavior for existing Terraform-managed sources while still preserving the intended default for brand-new resources.

## Testing
- `env GOCACHE=/tmp/go-build-cache /opt/homebrew/bin/go test ./census/provider -run 'TestResourceSource|TestGetConfiguredSourceSyncEngine'`
- Confirmed the following flow: 

1. create source on 0.2.10 (defaults to basic in the Census API)
2. upgrade to 0.2.12
3. observe that terraform plan wants to recreate it with advanced (the breaking change)
4. do not apply
5. upgrade to 0.2.13
6. re-run terraform plan
7. confirm no source replacement

## Release guidance
- Treat this as the `0.2.13` hotfix release
- Advise users to skip `0.2.12` and upgrade to `0.2.13`
- If users cannot upgrade immediately, pin to `0.2.11`
