### PR TITLE
Remove 0.2.12 references after registry deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,24 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.2.13] - 2026-04-21
 
-### Fixed
-- **Existing Source Sync Engine Preservation**: `census_source` no longer treats an omitted `sync_engine` argument as an instruction to replace existing sources during provider upgrades. New sources still default to `advanced`, but existing managed sources now keep their current engine unless `sync_engine` is set explicitly in configuration.
-
-### Upgrade Guidance
-- If you are on `0.2.12`, upgrade directly to `0.2.13`.
-- Avoid applying `0.2.12` when `census_source.sync_engine` is omitted from configuration.
-- If you need time before upgrading, pin to `0.2.11`.
-
-## [0.2.12] - 2026-04-10
-
-### Warning
-- **Known Issue**: `0.2.12` can plan replacement of existing `census_source` resources when `sync_engine` is omitted from configuration. Because `sync_engine` is immutable and forces source recreation, this can affect downstream sync history. Upgrade to `0.2.13` instead.
-
 ### Added
-- **Configurable Source Sync Engine**: Added a `sync_engine` argument to `census_source`, allowing Terraform users to request either engine explicitly for supported source types such as Snowflake Warehouse Writeback.
-
-### Changed
-- **Advanced Source Engine by Default**: `census_source` now defaults `sync_engine` to `advanced` to match the Census UI. The field is stored in state when returned by the Census API and still forces source recreation when changed, because the Census API rejects in-place sync engine updates.
+- **Configurable Source Sync Engine**: Added a `sync_engine` argument to `census_source`, allowing Terraform users to request either engine explicitly for supported source types such as Snowflake Warehouse Writeback. New sources default to `advanced` to match the Census UI. Existing managed sources preserve their current engine when `sync_engine` is omitted from configuration, so upgrading the provider does not plan source replacement.
 
 ### Fixed
 - **Resource Read Error Handling**: Fixed `census_destination`, `census_source`, `census_dataset`, and `census_sync` read paths to preserve API read errors instead of silently clearing Terraform state. A shadowed `err` variable in the workspace-token lookup block caused `504` and timeout-style read failures to fall through to the `nil` resource branch, which could make Terraform treat an existing resource as missing and attempt to recreate it. The provider now correctly hard-fails on read errors while still clearing state for confirmed `404` responses.
@@ -186,7 +170,7 @@ terraform {
   required_providers {
     census = {
       source  = "sutrolabs/census"
-      version = "!= 0.2.12, ~> 0.2.0"
+      version = "~> 0.2.0"
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -12,14 +12,12 @@ A Terraform provider for managing [Census](https://getcensus.com) resources. Cen
 
 ## Installation
 
-> Warning: Avoid `0.2.12` if you manage any existing `census_source` resources with `sync_engine` omitted from configuration. `0.2.12` can plan source replacement for those resources, which may affect downstream sync history. Upgrade to `0.2.13` instead, or pin to `0.2.11` until you can upgrade safely.
-
 ```hcl
 terraform {
   required_providers {
     census = {
       source  = "sutrolabs/census"
-      version = "!= 0.2.12, ~> 0.2.0"
+      version = "~> 0.2.0"
     }
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,8 +9,6 @@ description: |-
 
 The Census provider allows you to manage [Census](https://getcensus.com) resources using Terraform. Census enables you to sync data from your warehouse to all your operational tools, and this provider allows you to manage Census infrastructure as code.
 
-> Warning: Avoid `0.2.12` if you manage any existing `census_source` resources with `sync_engine` omitted from configuration. `0.2.12` can plan source replacement for those resources, which may affect downstream sync history. Upgrade to `0.2.13` instead, or pin to `0.2.11` until you can upgrade safely.
-
 ## Example Usage
 
 ```terraform
@@ -18,7 +16,7 @@ terraform {
   required_providers {
     census = {
       source  = "sutrolabs/census"
-      version = "!= 0.2.12, ~> 0.2.0"
+      version = "~> 0.2.0"
     }
   }
 }

--- a/docs/resources/source.md
+++ b/docs/resources/source.md
@@ -2,8 +2,6 @@
 
 Manages a Census data source connection. Sources connect to data warehouses like Snowflake, BigQuery, Postgres, and others.
 
-> Warning: Avoid provider version `0.2.12` if this resource omits `sync_engine`. `0.2.12` can plan replacement of existing `census_source` resources that were created before `sync_engine` support was added, which may affect downstream sync history. Upgrade to `0.2.13` instead, or pin to `0.2.11` until you can upgrade safely.
-
 ## Example Usage
 
 ### Snowflake Source (Password Authentication)


### PR DESCRIPTION
## Summary
- Consolidates the `0.2.12` CHANGELOG section into `0.2.13` now that `0.2.12` is being deleted from the Terraform Registry.
- Removes the \"Avoid 0.2.12\" warning blocks and `!= 0.2.12` version constraints from README, `docs/index.md`, and `docs/resources/source.md`.
- No code changes — the `sync_engine` feature and the preservation fix from PR #22 remain in 0.2.13 as the first public release containing them.

## Why
Because the only affected users (5 of them) are being told to upgrade directly and `0.2.12` will be removed from the Registry, the warnings and `!= 0.2.12` constraints would just send readers chasing a version that no longer exists.

## Test plan
- [ ] Delete `v0.2.12` tag and GitHub Release; confirm Terraform Registry delists it.
- [ ] Merge this PR, tag `v0.2.13` on `main`, push tag, create Release.
- [ ] Ask the 5 users to update their provider constraint and run `terraform init -upgrade`, then `terraform plan` (expect no diff for existing sources).

🤖 Generated with [Claude Code](https://claude.com/claude-code)