### PR TITLE
RD-1200789: add configurable warehouse_writeback_retention_in_days for census_source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Configurable Warehouse Writeback**: Added a `warehouse_writeback_retention_in_days` argument to `census_source`. Setting this enables Warehouse Writeback on the source and configures the sync log retention period in days. Supported on the advanced sync engine and on source types that support sync logs (Snowflake, BigQuery, Databricks, Redshift). The retention period can be updated in place; the Census API does not currently expose a way to disable Warehouse Writeback once enabled.
+
 ## [0.2.13] - 2026-04-21
 
 ### Added

--- a/census/client/source.go
+++ b/census/client/source.go
@@ -9,17 +9,18 @@ import (
 
 // Source represents a Census data source
 type Source struct {
-	ID          int                    `json:"id"`
-	WorkspaceID string                 `json:"workspace_id,omitempty"`
-	Name        string                 `json:"name"`
-	Type        string                 `json:"type"`
-	SyncEngine  string                 `json:"sync_engine,omitempty"`
-	CreatedAt   time.Time              `json:"created_at"`
-	UpdatedAt   time.Time              `json:"updated_at"`
-	Connection  map[string]interface{} `json:"connection"`
-	Status      string                 `json:"status,omitempty"`
-	TestStatus  string                 `json:"test_status,omitempty"`
-	LastTested  *time.Time             `json:"last_tested,omitempty"`
+	ID                                int                    `json:"id"`
+	WorkspaceID                       string                 `json:"workspace_id,omitempty"`
+	Name                              string                 `json:"name"`
+	Type                              string                 `json:"type"`
+	SyncEngine                        string                 `json:"sync_engine,omitempty"`
+	WarehouseWritebackRetentionInDays *int                   `json:"warehouse_writeback_retention_in_days,omitempty"`
+	CreatedAt                         time.Time              `json:"created_at"`
+	UpdatedAt                         time.Time              `json:"updated_at"`
+	Connection                        map[string]interface{} `json:"connection"`
+	Status                            string                 `json:"status,omitempty"`
+	TestStatus                        string                 `json:"test_status,omitempty"`
+	LastTested                        *time.Time             `json:"last_tested,omitempty"`
 }
 
 // CreateSourceRequest represents the request to create a source
@@ -29,10 +30,11 @@ type CreateSourceRequest struct {
 
 // SourceConnection represents the connection configuration for a source
 type SourceConnection struct {
-	Name        string                 `json:"name"`
-	Type        string                 `json:"type,omitempty"`
-	SyncEngine  string                 `json:"sync_engine,omitempty"`
-	Credentials map[string]interface{} `json:"credentials"`
+	Name                              string                 `json:"name"`
+	Type                              string                 `json:"type,omitempty"`
+	SyncEngine                        string                 `json:"sync_engine,omitempty"`
+	WarehouseWritebackRetentionInDays *int                   `json:"warehouse_writeback_retention_in_days,omitempty"`
+	Credentials                       map[string]interface{} `json:"credentials"`
 }
 
 // UpdateSourceRequest represents the request to update a source

--- a/census/provider/resource_source.go
+++ b/census/provider/resource_source.go
@@ -63,6 +63,11 @@ func resourceSource() *schema.Resource {
 				ForceNew:    true,
 				Description: "The sync engine to use for the source. New sources default to `advanced` to match the Census UI. Leave this unset to preserve the current engine on existing sources, or set it explicitly to `basic` or `advanced` to manage it in Terraform.",
 			},
+			"warehouse_writeback_retention_in_days": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "Enables Warehouse Writeback for the source and sets the sync log retention period (in days). Only supported on the advanced sync engine and on source types that support sync logs (Snowflake, BigQuery, Databricks, Redshift). Setting this enables Warehouse Writeback. Once enabled, the Census API does not currently support disabling it via this attribute; remove the attribute in Terraform to stop managing the value.",
+			},
 			"connection_config": {
 				Type:        schema.TypeMap,
 				Required:    true,
@@ -135,10 +140,11 @@ func resourceSourceCreate(ctx context.Context, d *schema.ResourceData, meta inte
 
 	req := &client.CreateSourceRequest{
 		Connection: client.SourceConnection{
-			Name:        name, // Set name inside connection per API requirements
-			Type:        sourceType,
-			SyncEngine:  syncEngine,
-			Credentials: connectionConfig,
+			Name:                              name, // Set name inside connection per API requirements
+			Type:                              sourceType,
+			SyncEngine:                        syncEngine,
+			WarehouseWritebackRetentionInDays: getConfiguredWarehouseWritebackRetention(d),
+			Credentials:                       connectionConfig,
 		},
 	}
 
@@ -222,6 +228,9 @@ Where 69962 is the workspace_id for marketing_prod workspace.`)
 	if syncEngine := getSourceSyncEngine(source); syncEngine != "" {
 		d.Set("sync_engine", syncEngine)
 	}
+	if source.WarehouseWritebackRetentionInDays != nil {
+		d.Set("warehouse_writeback_retention_in_days", *source.WarehouseWritebackRetentionInDays)
+	}
 	d.Set("name", source.Name)
 	d.Set("type", source.Type)
 	d.Set("status", source.Status)
@@ -271,6 +280,20 @@ func getConfiguredSourceSyncEngine(d *schema.ResourceData) string {
 	return "advanced"
 }
 
+func getConfiguredWarehouseWritebackRetention(d *schema.ResourceData) *int {
+	raw, ok := d.GetOk("warehouse_writeback_retention_in_days")
+	if !ok {
+		return nil
+	}
+
+	retention, ok := raw.(int)
+	if !ok || retention <= 0 {
+		return nil
+	}
+
+	return &retention
+}
+
 func resourceSourceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	apiClient := meta.(*client.Client)
 
@@ -306,7 +329,8 @@ func resourceSourceUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 		Connection: client.SourceConnection{
 			Name: name, // Set name in connection structure per API requirements
 			// Note: Type and SyncEngine cannot be modified after creation per Census API
-			Credentials: connectionConfig,
+			WarehouseWritebackRetentionInDays: getConfiguredWarehouseWritebackRetention(d),
+			Credentials:                       connectionConfig,
 		},
 	}
 

--- a/census/provider/resource_source_test.go
+++ b/census/provider/resource_source_test.go
@@ -126,6 +126,150 @@ func TestResourceSourceSchema_SyncEngineIsForceNew(t *testing.T) {
 	}
 }
 
+func TestResourceSourceCreate_OmitsWarehouseWritebackByDefault(t *testing.T) {
+	t.Parallel()
+
+	captured, diags, d := runSourceCreateRequestTest(t, nil)
+	if diags.HasError() {
+		t.Fatalf("expected source creation to succeed, got diagnostics: %#v", diags)
+	}
+
+	if captured.WarehouseWritebackRetentionInDays != nil {
+		t.Fatalf("expected warehouse_writeback_retention_in_days to be omitted, got %v", *captured.WarehouseWritebackRetentionInDays)
+	}
+
+	if got, ok := d.GetOk("warehouse_writeback_retention_in_days"); ok {
+		t.Fatalf("expected state to omit warehouse_writeback_retention_in_days, got %v", got)
+	}
+}
+
+func TestResourceSourceCreate_SendsWarehouseWritebackRetention(t *testing.T) {
+	t.Parallel()
+
+	retention := 30
+	captured, diags, d := runSourceCreateRequestTest(t, &retention)
+	if diags.HasError() {
+		t.Fatalf("expected source creation to succeed, got diagnostics: %#v", diags)
+	}
+
+	if captured.WarehouseWritebackRetentionInDays == nil {
+		t.Fatalf("expected create request to include warehouse_writeback_retention_in_days, got nil")
+	}
+	if *captured.WarehouseWritebackRetentionInDays != retention {
+		t.Fatalf("expected create request retention %d, got %d", retention, *captured.WarehouseWritebackRetentionInDays)
+	}
+
+	if got := d.Get("warehouse_writeback_retention_in_days").(int); got != retention {
+		t.Fatalf("expected state retention %d, got %d", retention, got)
+	}
+}
+
+func TestResourceSourceRead_PopulatesWarehouseWritebackFromAPI(t *testing.T) {
+	t.Parallel()
+
+	const (
+		workspaceID = 69962
+		sourceID    = 2280673
+		retention   = 45
+	)
+
+	apiClient := newSourceTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/workspaces/69962/api_key":
+			writeJSON(t, w, http.StatusOK, map[string]string{"api_key": "workspace-token"})
+		case "/sources/2280673":
+			if r.Method != http.MethodGet {
+				t.Fatalf("unexpected method for %s: %s", r.URL.Path, r.Method)
+			}
+			resp := buildSourceResponse(sourceID, "advanced")
+			data := resp["data"].(map[string]interface{})
+			data["warehouse_writeback_retention_in_days"] = retention
+			writeJSON(t, w, http.StatusOK, resp)
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	d := schema.TestResourceDataRaw(t, resourceSource().Schema, map[string]interface{}{
+		"workspace_id":      strconv.Itoa(workspaceID),
+		"name":              "Warehouse Source",
+		"type":              "snowflake",
+		"connection_config": map[string]interface{}{"account": "acct"},
+	})
+	d.SetId(strconv.Itoa(sourceID))
+
+	diags := resourceSourceRead(context.Background(), d, apiClient)
+	if diags.HasError() {
+		t.Fatalf("expected source read to succeed, got diagnostics: %#v", diags)
+	}
+
+	if got := d.Get("warehouse_writeback_retention_in_days").(int); got != retention {
+		t.Fatalf("expected read to set warehouse_writeback_retention_in_days to %d, got %d", retention, got)
+	}
+}
+
+func TestResourceSourceSchema_WarehouseWritebackIsUpdateable(t *testing.T) {
+	t.Parallel()
+
+	field := resourceSource().Schema["warehouse_writeback_retention_in_days"]
+	if field == nil {
+		t.Fatal("expected warehouse_writeback_retention_in_days field to exist on census_source")
+	}
+	if field.ForceNew {
+		t.Fatal("expected warehouse_writeback_retention_in_days to be updateable in place (not ForceNew); the Census source update endpoint accepts changes to retention")
+	}
+	if field.Type != schema.TypeInt {
+		t.Fatalf("expected warehouse_writeback_retention_in_days to be TypeInt, got %v", field.Type)
+	}
+}
+
+func TestGetConfiguredWarehouseWritebackRetention(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name       string
+		configured interface{}
+		want       *int
+	}{
+		{name: "omitted returns nil"},
+		{name: "zero returns nil", configured: 0},
+		{name: "negative returns nil", configured: -1},
+		{name: "positive returns pointer", configured: 30, want: intPtr(30)},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			raw := map[string]interface{}{
+				"workspace_id":      "69962",
+				"name":              "Warehouse Source",
+				"type":              "snowflake",
+				"connection_config": map[string]interface{}{"account": "acct"},
+			}
+			if tc.configured != nil {
+				raw["warehouse_writeback_retention_in_days"] = tc.configured
+			}
+
+			d := schema.TestResourceDataRaw(t, resourceSource().Schema, raw)
+			got := getConfiguredWarehouseWritebackRetention(d)
+			switch {
+			case tc.want == nil && got == nil:
+				// ok
+			case tc.want == nil && got != nil:
+				t.Fatalf("expected nil, got pointer to %d", *got)
+			case tc.want != nil && got == nil:
+				t.Fatalf("expected pointer to %d, got nil", *tc.want)
+			case *tc.want != *got:
+				t.Fatalf("expected %d, got %d", *tc.want, *got)
+			}
+		})
+	}
+}
+
+func intPtr(v int) *int { return &v }
+
 func TestGetConfiguredSourceSyncEngine(t *testing.T) {
 	t.Parallel()
 
@@ -235,6 +379,78 @@ func runSourceCreateTest(t *testing.T, syncEngine string) (string, diag.Diagnost
 	diags := resourceSourceCreate(context.Background(), d, apiClient)
 
 	return capturedSyncEngine, diags, d
+}
+
+func runSourceCreateRequestTest(t *testing.T, retention *int) (client.SourceConnection, diag.Diagnostics, *schema.ResourceData) {
+	t.Helper()
+
+	const (
+		workspaceID = 69962
+		sourceID    = 2280673
+	)
+
+	var captured client.SourceConnection
+
+	apiClient := newSourceTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/workspaces/69962/api_key":
+			writeJSON(t, w, http.StatusOK, map[string]string{"api_key": "workspace-token"})
+		case "/source_types":
+			writeJSON(t, w, http.StatusOK, map[string]interface{}{
+				"status": "success",
+				"data": []map[string]interface{}{
+					{
+						"service_name": "snowflake",
+						"configuration_fields": map[string]interface{}{
+							"fields": []map[string]interface{}{},
+						},
+					},
+				},
+			})
+		case "/sources":
+			if r.Method != http.MethodPost {
+				t.Fatalf("unexpected method for %s: %s", r.URL.Path, r.Method)
+			}
+
+			var req client.CreateSourceRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatalf("failed to decode create source request: %v", err)
+			}
+			captured = req.Connection
+
+			resp := buildSourceResponse(sourceID, req.Connection.SyncEngine)
+			if req.Connection.WarehouseWritebackRetentionInDays != nil {
+				resp["data"].(map[string]interface{})["warehouse_writeback_retention_in_days"] = *req.Connection.WarehouseWritebackRetentionInDays
+			}
+			writeJSON(t, w, http.StatusOK, resp)
+		case "/sources/2280673":
+			if r.Method != http.MethodGet {
+				t.Fatalf("unexpected method for %s: %s", r.URL.Path, r.Method)
+			}
+			resp := buildSourceResponse(sourceID, captured.SyncEngine)
+			if captured.WarehouseWritebackRetentionInDays != nil {
+				resp["data"].(map[string]interface{})["warehouse_writeback_retention_in_days"] = *captured.WarehouseWritebackRetentionInDays
+			}
+			writeJSON(t, w, http.StatusOK, resp)
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	raw := map[string]interface{}{
+		"workspace_id":      strconv.Itoa(workspaceID),
+		"name":              "Warehouse Source",
+		"type":              "snowflake",
+		"connection_config": map[string]interface{}{"account": "acct"},
+	}
+	if retention != nil {
+		raw["warehouse_writeback_retention_in_days"] = *retention
+	}
+
+	d := schema.TestResourceDataRaw(t, resourceSource().Schema, raw)
+	diags := resourceSourceCreate(context.Background(), d, apiClient)
+
+	return captured, diags, d
 }
 
 func newSourceTestClient(t *testing.T, handler http.HandlerFunc) *client.Client {

--- a/docs/resources/source.md
+++ b/docs/resources/source.md
@@ -43,6 +43,28 @@ resource "census_source" "warehouse_basic" {
 }
 ```
 
+### Snowflake Source (Warehouse Writeback Enabled)
+
+```hcl
+resource "census_source" "warehouse_with_writeback" {
+  workspace_id = census_workspace.main.id
+  name         = "Production Warehouse"
+  type         = "snowflake"
+  sync_engine  = "advanced"
+
+  warehouse_writeback_retention_in_days = 30
+
+  connection_config = {
+    account   = "abc12345.us-east-1"
+    warehouse = "COMPUTE_WH"
+    database  = "PRODUCTION"
+    username  = "census_user"
+    password  = var.snowflake_password
+    role      = "CENSUS_ROLE"
+  }
+}
+```
+
 ### Snowflake Source (Keypair Authentication)
 
 ```hcl
@@ -111,6 +133,7 @@ resource "census_source" "postgres" {
   - `mysql`
   - And many more... (validated against Census API)
 * `sync_engine` - (Optional, Computed, Forces new resource) The sync engine to use when the source is created. New sources default to `advanced` to match the Census UI. Leave this unset to preserve the current engine on existing sources, or set it explicitly to `basic` only when you need the basic engine.
+* `warehouse_writeback_retention_in_days` - (Optional) Enables Warehouse Writeback for the source and sets the sync log retention period (in days). Setting this attribute enables the feature; omit it to leave Warehouse Writeback unconfigured. Only supported on the `advanced` sync engine and on source types that support sync logs (Snowflake, BigQuery, Databricks, Redshift). The Census API rejects requests that set this on unsupported source types or basic-engine sources.
 * `connection_config` - (Required, Sensitive) Map of credentials for connecting to the source. Supports strings, numbers, and booleans. The required fields vary by source type and are validated against the Census API schema.
 
 ## Attribute Reference
@@ -144,3 +167,4 @@ terraform import census_source.warehouse "12345:67890"
 * `sync_engine` is a create-time setting. The Census API rejects in-place sync engine changes with a 4xx response, so Terraform recreates the source when this field changes.
 * Leaving `sync_engine` unset creates new sources with the advanced engine by default, but preserves the current engine for existing managed sources to avoid unexpected replacements during provider upgrades.
 * If you already use `sync_engine`, set it explicitly in configuration so future provider upgrades cannot infer a different value from a changing default.
+* `warehouse_writeback_retention_in_days` can be increased or decreased on an existing managed source by changing the value in configuration; the provider issues a PATCH on the next apply. The Census API does not currently expose a way to disable Warehouse Writeback once enabled, so removing this attribute from configuration stops Terraform from managing the value but does not turn the feature off in Census. Use the Census UI if you need to disable it.


### PR DESCRIPTION
## Summary
Adds a `warehouse_writeback_retention_in_days` argument to `census_source`. Setting it enables Warehouse Writeback on a source and configures the sync log retention period. The value can be updated in place via the Census source PATCH endpoint.

## Design

- Single optional `Int` field. The Census source API takes one parameter (`warehouse_writeback_retention_in_days`) where presence enables the feature; mirroring the API directly avoids invalid states (e.g. enabled with no retention).
- Updateable, not `ForceNew`. The Census source update endpoint accepts changes to retention.
- No client-side validation. The Census API rejects the field on source types that don't support sync logs and on basic-engine sources, with a useful error.
- The Census API does not currently expose disabling Warehouse Writeback once enabled; this is documented on the resource page.

## Files

- `census/client/source.go` — adds `WarehouseWritebackRetentionInDays *int` to `Source` and `SourceConnection`.
- `census/provider/resource_source.go` — adds the schema field, populates it on create/update/read, plus a `getConfiguredWarehouseWritebackRetention` helper.
- `census/provider/resource_source_test.go` — unit tests covering create with/without the field, read populating state from API, schema is updateable, helper edge cases.
- `docs/resources/source.md` — usage example and argument reference.
- `CHANGELOG.md` — Unreleased entry.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `gofmt -l .` (clean)
- [ ] Live apply against a Snowflake source with `sync_engine = "advanced"` and a retention value
- [ ] Verify `terraform plan` is no-op after a successful apply (no drift)
- [ ] Verify retention can be increased and decreased in place

🤖 Generated with [Claude Code](https://claude.com/claude-code)
